### PR TITLE
fix: align Perigon /stories API with real endpoint

### DIFF
--- a/backend/src/services/perigon.py
+++ b/backend/src/services/perigon.py
@@ -330,7 +330,7 @@ async def fetch_perigon_stories(
     size: int = 10,
     source_group: str = "top100",
 ) -> list[dict]:
-    """Fetch clustered stories from Perigon /v1/stories endpoint.
+    """Fetch clustered stories from Perigon /v1/stories/all endpoint.
 
     Stories represent clusters of articles about the same event.
     High uniqueCount = broad coverage = likely high-impact macro event.

--- a/backend/tests/test_perigon_stories.py
+++ b/backend/tests/test_perigon_stories.py
@@ -1,4 +1,8 @@
-from src.services.perigon import _story_to_pool_item
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from src.services.perigon import _story_to_pool_item, fetch_perigon_stories
 
 
 def test_story_to_pool_item_basic():
@@ -72,3 +76,81 @@ def test_story_fallback_to_updated_at():
     }
     item = _story_to_pool_item(story)
     assert item["published_at"] == "2026-03-24T10:00:00Z"
+
+
+# --- fetch_perigon_stories() tests ---
+
+
+@pytest.mark.asyncio
+@patch("src.services.perigon.PERIGON_API_KEY", "test-key")
+@patch("src.services.perigon._get_cached", new_callable=AsyncMock, return_value=None)
+@patch("src.services.perigon._get_call_count_today", new_callable=AsyncMock, return_value=0)
+@patch("src.services.perigon._increment_call_count", new_callable=AsyncMock)
+@patch("src.services.perigon._set_cache", new_callable=AsyncMock)
+async def test_fetch_perigon_stories_uses_stories_all_path(
+    mock_set_cache, mock_inc, mock_count, mock_cached
+):
+    """Verify fetch_perigon_stories hits /v1/stories/all and parses 'results' key."""
+    mock_response = MagicMock()
+    mock_response.json.return_value = {
+        "status": 200,
+        "results": [
+            {
+                "id": "story1",
+                "name": "Fed holds rates steady",
+                "summary": "The Federal Reserve...",
+                "uniqueCount": 25,
+                "totalCount": 30,
+                "initializedAt": "2026-03-25T12:00:00Z",
+                "updatedAt": "2026-03-25T13:00:00Z",
+                "topics": [{"name": "Federal Reserve"}],
+                "categories": [{"name": "Economy"}],
+                "sentiment": {"positive": 0.3, "negative": 0.2},
+            },
+        ],
+    }
+
+    mock_client = AsyncMock()
+    mock_client.get.return_value = mock_response
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=False)
+
+    with patch("src.services.perigon.httpx.AsyncClient", return_value=mock_client):
+        result = await fetch_perigon_stories(size=5)
+
+    # Verify the correct URL path was called
+    call_args = mock_client.get.call_args
+    url = call_args[0][0]
+    assert "/stories/all" in url, f"Expected /stories/all in URL, got: {url}"
+
+    # Verify results were parsed correctly
+    assert len(result) == 1
+    assert result[0]["title"] == "Fed holds rates steady"
+    assert result[0]["story_cluster_size"] == 25
+    assert result[0]["origin"] == "perigon"
+
+
+@pytest.mark.asyncio
+@patch("src.services.perigon.PERIGON_API_KEY", "test-key")
+@patch("src.services.perigon._get_cached", new_callable=AsyncMock, return_value=None)
+@patch("src.services.perigon._get_call_count_today", new_callable=AsyncMock, return_value=0)
+@patch("src.services.perigon._increment_call_count", new_callable=AsyncMock)
+async def test_fetch_perigon_stories_non_200_returns_empty(
+    mock_inc, mock_count, mock_cached
+):
+    """Verify non-200 status from Perigon returns empty list."""
+    mock_response = MagicMock()
+    mock_response.json.return_value = {
+        "status": 400,
+        "message": "Invalid API key",
+    }
+
+    mock_client = AsyncMock()
+    mock_client.get.return_value = mock_response
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=False)
+
+    with patch("src.services.perigon.httpx.AsyncClient", return_value=mock_client):
+        result = await fetch_perigon_stories()
+
+    assert result == []


### PR DESCRIPTION
## Summary
- Verified Perigon `/stories` endpoint against live API — correct path is `/stories/all` (old `/stories` returns 404)
- Fixed field name mismatches: `storyId`→`id`, `title`→`name`, `numArticles`→`uniqueCount`, `initialPublishedAt`→`initializedAt`
- Removed nonexistent `url` field from pool item output
- Removed unnecessary `stories` fallback key in response parsing (`results` is correct)

## Field mapping (verified against real API)

| Code assumed | Real API field | Status |
|---|---|---|
| `storyId` | `id` | Fixed |
| `title` | `name` | Fixed |
| `numArticles` | `uniqueCount` (fallback: `totalCount`) | Fixed |
| `initialPublishedAt` | `initializedAt` (fallback: `updatedAt`) | Fixed |
| `url` | *(not present)* | Removed |

## Test plan
- [x] Unit tests updated to match real API field names (4 tests, all pass)
- [x] Added fallback tests for `totalCount` and `updatedAt`
- [x] Full test suite passes (404 passed, 1 skipped)

Closes #14

🤖 Generated with [Claude Code](https://claude.com/claude-code)