### PR TITLE
fix: add crewai to pyproject.toml dependencies

### DIFF
--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -11,6 +11,8 @@ dependencies = [
     "pydantic-settings>=2.7",
     "python-jose>=3.3",
     "bcrypt>=4.2",
+    "crewai>=0.80",
+    "httpx>=0.28",
 ]
 
 [build-system]
@@ -28,4 +30,4 @@ markers = [
 ]
 
 [project.optional-dependencies]
-dev = ["pytest>=8.0", "pytest-asyncio>=0.24", "pytest-cov>=6.0", "httpx>=0.28", "deepeval>=2.0"]
+dev = ["pytest>=8.0", "pytest-asyncio>=0.24", "pytest-cov>=6.0", "deepeval>=2.0"]


### PR DESCRIPTION
## Summary
- Add `crewai>=0.80` to `[project.dependencies]` — used by `thinking_crew.py`, `llm_config.py`, `fetch_news.py`, and `skills/base.py`
- Promote `httpx>=0.28` from `[dev]` to main dependencies — used in production code (`perigon.py`, `data_sources.py`, `newsapi.py`)

Closes #21

## Test Plan
- [ ] `pip install -e 'backend[dev]'` resolves all dependencies
- [ ] `python -c "import crewai; import httpx"` succeeds
- [ ] Existing tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)