### PR TITLE
fix: add litellm to dev dependencies

### DIFF
--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -28,4 +28,4 @@ markers = [
 ]
 
 [project.optional-dependencies]
-dev = ["pytest>=8.0", "pytest-asyncio>=0.24", "pytest-cov>=6.0", "httpx>=0.28", "deepeval>=2.0"]
+dev = ["deepeval>=2.0", "httpx>=0.28", "litellm>=1.0", "pytest>=8.0", "pytest-asyncio>=0.24", "pytest-cov>=6.0"]


### PR DESCRIPTION
## Summary
- Adds `litellm>=1.0` to `[project.optional-dependencies] dev` in `backend/pyproject.toml`
- Sorts the dependency list alphabetically
- Fixes #23 — `tests/benchmark/scoring/judge_models.py` imports `litellm` but it was missing from dev deps

## Test plan
- [ ] `pip install -e 'backend[dev]'` installs litellm
- [ ] `python -c "import litellm"` succeeds
- [ ] Existing tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)