### PR TITLE
fix: add missing crewai, httpx, litellm deps to pyproject.toml

### DIFF
--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -11,6 +11,8 @@ dependencies = [
     "pydantic-settings>=2.7",
     "python-jose>=3.3",
     "bcrypt>=4.2",
+    "crewai>=1.0",
+    "httpx>=0.28",
 ]
 
 [build-system]
@@ -28,4 +30,4 @@ markers = [
 ]
 
 [project.optional-dependencies]
-dev = ["pytest>=8.0", "pytest-asyncio>=0.24", "pytest-cov>=6.0", "httpx>=0.28", "deepeval>=2.0"]
+dev = ["pytest>=8.0", "pytest-asyncio>=0.24", "pytest-cov>=6.0", "pytest-mock>=3.14", "deepeval>=2.0", "litellm>=1.50"]


### PR DESCRIPTION
## Summary
- Add `crewai>=1.0` and `httpx>=0.28` to production dependencies (used by `thinking_crew.py` and `perigon.py`)
- Add `litellm>=1.50` and `pytest-mock>=3.14` to dev dependencies (used by benchmark judge models and tests)
- Move `httpx` from dev-only to production (runtime dependency)

Closes #21, closes #23

## Test Plan
- [x] All 406 tests pass on clean worktree
- [ ] `pip install -e '.[dev]'` in fresh venv installs all needed packages

🤖 Generated with [Claude Code](https://claude.com/claude-code)