### PR TITLE
chore: add project rules and update .gitignore

### DIFF
--- a/.claude/rules/docker-tests-from-worktree-cwd.md
+++ b/.claude/rules/docker-tests-from-worktree-cwd.md
@@ -1,0 +1,16 @@
+# Run Docker Tests from Worktree CWD, Not Main Repo
+
+## The Trap
+Running `docker compose run --rm --no-deps backend python -m pytest ...` from the main repo directory when working in a worktree. The `docker-compose.yml` volume mount (`./backend:/app`) resolves relative to CWD — so it mounts the main repo's `backend/`, not the worktree's. Tests pass but only run the main repo's test files, missing any new/changed tests in the worktree.
+
+## The Solution
+Always `cd` to the worktree directory before running `docker compose run`:
+```bash
+cd /path/to/worktree && docker compose run --rm --no-deps backend python -m pytest tests/... -v
+```
+Use `--no-deps` to avoid port conflicts with the main repo's already-running mongodb/redis containers.
+
+## Context
+- **When this applies:** Running backend tests in any worktree via Docker
+- **Related files:** `docker-compose.yml`, `backend/Dockerfile`
+- **Discovered:** 2026-03-25, during PR #15 review fix — only 2/6 tests collected because Docker mounted main repo files

--- a/.claude/rules/lazy-import-optional-deps.md
+++ b/.claude/rules/lazy-import-optional-deps.md
@@ -1,0 +1,22 @@
+# Lazy-Import Optional Dependencies in Composition Roots
+
+## The Trap
+Top-level imports of packages that require Docker services (qdrant-client, fastembed) in composition root files like `dependencies.py`. When `main.py` imports the module during lifespan, these packages must be installed — but the test environment uses mocks and doesn't have them. Result: `ModuleNotFoundError` in unrelated tests that trigger the lifespan (e.g., test_lifespan.py).
+
+## The Solution
+Move concrete implementation imports inside the `init_*()` function, not at module level:
+```python
+# DON'T: top-level import
+from src.rag.sparse_encoder import FastEmbedBM25  # pulls in fastembed at import time
+
+# DO: lazy import inside init function
+async def init_rag_services():
+    from src.rag.sparse_encoder import FastEmbedBM25  # only imported when actually initializing
+```
+
+Keep protocol/config imports at module level (they have no heavy deps). Only lazy-import concrete implementations that pull in optional packages.
+
+## Context
+- **When this applies:** Any composition root or dependency wiring that imports packages not in the base dev deps
+- **Related files:** `backend/src/rag/dependencies.py`
+- **Discovered:** 2026-03-26, during node RAG persistence implementation — 2 test failures from fastembed not installed

--- a/.claude/rules/qdrant-requires-uuid-point-ids.md
+++ b/.claude/rules/qdrant-requires-uuid-point-ids.md
@@ -1,0 +1,23 @@
+# Qdrant Requires UUID or Integer Point IDs
+
+## The Trap
+Passing arbitrary string IDs (e.g., `"n1"`, `"eff_001"`) as Qdrant point IDs. Qdrant rejects them with: `"value n1 is not a valid point ID, valid values are either an unsigned integer or a UUID"`. This only surfaces at runtime against a real Qdrant instance — unit tests with FakeVectorStore accept any string.
+
+## The Solution
+Convert string node IDs to deterministic UUID5s before upserting to Qdrant. Store the original ID in the payload for round-tripping:
+```python
+import uuid
+_NAMESPACE = uuid.UUID("a1b2c3d4-e5f6-7890-abcd-ef1234567890")
+
+def _str_to_uuid(s: str) -> str:
+    return str(uuid.uuid5(_NAMESPACE, s))
+
+# Upsert: id=_str_to_uuid(node_id), payload={..., "_original_id": node_id}
+# Query: pop "_original_id" from payload, return as the result ID
+# Delete: convert IDs to UUIDs before passing to Qdrant
+```
+
+## Context
+- **When this applies:** Any code that upserts/deletes points in Qdrant using string IDs
+- **Related files:** `backend/src/rag/qdrant_store.py`
+- **Discovered:** 2026-03-26, during Qdrant integration tests — all 10 upsert/query/delete tests failed with 400 Bad Request

--- a/.claude/rules/qdrant-sparse-indices-must-be-unique.md
+++ b/.claude/rules/qdrant-sparse-indices-must-be-unique.md
@@ -1,0 +1,19 @@
+# Qdrant Sparse Vector Indices Must Be Unique
+
+## The Trap
+Sending sparse vectors with duplicate indices to Qdrant. Hash-based tokenizers can produce collisions (two different words hash to the same index). Qdrant rejects with: `"Validation error: must be unique"`. Unit tests with FakeVectorStore don't catch this — only surfaces against real Qdrant.
+
+## The Solution
+Deduplicate sparse indices before upserting. Aggregate weights for colliding tokens:
+```python
+seen: dict[int, float] = {}
+for token in tokens:
+    idx = hash(token) % vocab_size
+    seen[idx] = seen.get(idx, 0.0) + 1.0
+return list(seen.keys()), list(seen.values())
+```
+
+## Context
+- **When this applies:** Any sparse vector encoder used with Qdrant (FakeSparseEncoder, FastEmbedBM25, or custom)
+- **Related files:** `backend/src/rag/fakes.py` (FakeSparseEncoder)
+- **Discovered:** 2026-03-26, E2E test — all upserts failed with 422 Unprocessable Entity

--- a/.claude/rules/vite-proxy-must-read-api-url-env.md
+++ b/.claude/rules/vite-proxy-must-read-api-url-env.md
@@ -1,0 +1,15 @@
+# Vite Proxy Must Read VITE_API_URL in Docker
+
+## The Trap
+Hardcoding `http://127.0.0.1:${port}` as the Vite proxy target. Works locally but fails in Docker — the backend is at the `backend` service hostname, not `127.0.0.1`. Pools return empty because every proxy request gets `ECONNREFUSED`.
+
+## The Solution
+`vite.config.ts` must prefer `VITE_API_URL` (set in docker-compose.yml) over localhost fallback:
+```ts
+const apiTarget = process.env.VITE_API_URL || `http://127.0.0.1:${apiPort}`;
+```
+
+## Context
+- **When this applies:** Any change to vite.config.ts proxy settings or docker-compose frontend env
+- **Related files:** `frontend/vite.config.ts`, `docker-compose.yml`
+- **Discovered:** 2026-03-25, pools appeared empty on every Docker restart

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,9 @@
 # Python virtual environments
 .venv/
 backend/.venv/
+
+# DeepEval cache
+backend/.deepeval/
+
+# Worktree artifacts
+worktrees/


### PR DESCRIPTION
## Summary
- Track 5 project-specific rules discovered during recent feature work (Docker worktree testing, lazy imports, Qdrant ID/index constraints, Vite proxy env)
- Update `.gitignore` to exclude `backend/.deepeval/` cache and `worktrees/` artifacts

## Test plan
- [x] No code changes — rules and gitignore only
- [x] Verify `.gitignore` entries match intended directories

🤖 Generated with [Claude Code](https://claude.com/claude-code)