### PR TITLE
fix: thinking view — missing confidence, broken edges, node overlap

### DIFF
--- a/backend/src/services/thinking_service.py
+++ b/backend/src/services/thinking_service.py
@@ -310,7 +310,18 @@ async def run_layer_streaming(
             _push("layer_complete", {"layer": layer, "reason": "no effects"})
             return _empty_layer_result("Thinker produced no effects")
 
+        # Remap batch IDs → streaming IDs so edges match frontend nodes
+        batch_to_stream = {
+            node["id"]: index_to_id[i]
+            for i, node in enumerate(effect_nodes)
+            if i in index_to_id
+        }
+        for node in effect_nodes:
+            node["id"] = batch_to_stream.get(node["id"], node["id"])
         all_edges = list(effect_edges) + list(fetch_edges)
+        for edge in all_edges:
+            edge["source"] = batch_to_stream.get(edge["source"], edge["source"])
+            edge["target"] = batch_to_stream.get(edge["target"], edge["target"])
 
         # Push edges from thinker
         _push("edges", {"edges": all_edges, "source": "thinker"})
@@ -433,11 +444,8 @@ async def run_pipeline(
 
         # Accumulate this layer's nodes for future parent collection
         all_layer_nodes.append(all_new_nodes)
-
-        # Update chain summary from controller
         chain_summary = result.controller_decision.get("summary", chain_summary)
 
-        # Termination: controller says stop or no effects produced
         if not result.controller_decision.get("continue", False):
             log.info(
                 "Pipeline stopping at layer %d: %s",

--- a/frontend/src/components/StreamingNode.tsx
+++ b/frontend/src/components/StreamingNode.tsx
@@ -47,14 +47,16 @@ function StreamingNodeComponent({ data }: NodeProps) {
             style={{ opacity: 0.6 }}
           />
         )}
-        {d.confidence != null && !d.streaming && (
-          <div
-            className="mt-1 text-[10px]"
-            style={{ color: isOpp ? "#86efac" : "#9ca3af" }}
-          >
-            {d.confidence}% confidence
-          </div>
-        )}
+        {typeof d.confidence === "number" &&
+          !Number.isNaN(d.confidence) &&
+          !d.streaming && (
+            <div
+              className="mt-1 text-[10px]"
+              style={{ color: isOpp ? "#86efac" : "#9ca3af" }}
+            >
+              {d.confidence}% confidence
+            </div>
+          )}
       </div>
       <Handle type="source" position={Position.Bottom} style={{ opacity: 0 }} />
     </div>

--- a/frontend/src/lib/thinking-graph-builder.ts
+++ b/frontend/src/lib/thinking-graph-builder.ts
@@ -65,7 +65,7 @@ export function concentricPosition(
   layer: number,
   index: number,
   totalInLayer: number,
-  layerRadius: number = 180,
+  layerRadius: number = 250,
 ): { x: number; y: number } {
   if (layer === 0) {
     const angle = (index / Math.max(totalInLayer, 1)) * 2 * Math.PI;
@@ -83,9 +83,10 @@ export function buildThinkingGraph(
   edges: ThinkingEdge[],
   fixedPositions?: Map<string, { x: number; y: number }>,
 ): { rfNodes: RFNode[]; rfEdges: RFEdge[] } {
-  // Build React Flow nodes
+  // Build React Flow nodes — use StreamingNode type so confidence renders
   const rfNodes: RFNode[] = nodes.map((n) => ({
     id: n.id,
+    type: "streaming",
     position: { x: 0, y: 0 },
     data: {
       label: n.content,
@@ -93,6 +94,11 @@ export function buildThinkingGraph(
       layer: n.layer,
       selected: n.selected,
       reasoning: n.reasoning,
+      streaming: false,
+      confidence:
+        (n.metadata?.confidence as number) ??
+        (n as unknown as Record<string, unknown>).confidence ??
+        undefined,
     },
     style: nodeStyle(n.type, n.selected, n.layer),
   }));
@@ -133,12 +139,12 @@ export function buildThinkingGraph(
   // Apply concentric ring layout — strong repulsion to prevent overlap
   const layerMap = new Map(nodes.map((n) => [n.id, n.layer]));
   const layoutNodes = layoutGraph(rfNodes, rfEdges, {
-    chargeStrength: -600,
-    linkDistance: 150,
-    collideRadius: 100,
-    iterations: 150,
+    chargeStrength: -800,
+    linkDistance: 200,
+    collideRadius: 130,
+    iterations: 200,
     layerMap,
-    layerRadius: 180,
+    layerRadius: 250,
     fixedPositions,
   });
 

--- a/frontend/src/lib/thinking-graph-builder.ts
+++ b/frontend/src/lib/thinking-graph-builder.ts
@@ -96,8 +96,8 @@ export function buildThinkingGraph(
       reasoning: n.reasoning,
       streaming: false,
       confidence:
+        ((n as unknown as Record<string, unknown>).confidence as number) ??
         (n.metadata?.confidence as number) ??
-        (n as unknown as Record<string, unknown>).confidence ??
         undefined,
     },
     style: nodeStyle(n.type, n.selected, n.layer),


### PR DESCRIPTION
## Summary
- **Confidence display**: `buildThinkingGraph` now includes confidence from node metadata and sets `type: "streaming"` so `StreamingNode` renders for DB-loaded sessions. Hardened check to `typeof === "number"` to prevent rendering empty/non-numeric values as "% confidence".
- **Broken edges**: `run_layer_streaming` remaps `_build_thinker_output` batch IDs to streaming IDs, so edges reference the same node IDs the frontend knows. Previously, batch and streaming paths generated independent UUIDs for the same effects.
- **Node overlap**: Increased d3-force layout params (collideRadius 100→130, chargeStrength -600→-800, linkDistance 150→200, layerRadius 180→250) to prevent nodes from overlapping.

## Root Causes
1. `buildThinkingGraph` didn't pass `confidence` or `type: "streaming"` to React Flow nodes → StreamingNode wasn't used for loaded sessions
2. `_build_thinker_output` generates `uuid4()` per effect, separate from the streaming UUIDs in `index_to_id` → edges referenced non-existent node IDs
3. `collideRadius: 100` was too small for nodes up to 200px wide

## Test plan
- [x] Frontend builds (`npm run build`)
- [ ] Load a completed thinking session — verify confidence numbers display
- [ ] Run auto-think — verify edges appear between news→effects
- [ ] Verify nodes don't overlap with 5+ effects on a layer

🤖 Generated with [Claude Code](https://claude.com/claude-code)