### PR TITLE
feat: cron pre-populate + thinking graph UX overhaul

### DIFF
--- a/backend/src/cron/scheduler.py
+++ b/backend/src/cron/scheduler.py
@@ -115,10 +115,27 @@ async def run_news_pipeline() -> None:
             result.rescored,
         )
 
+        # Sync active articles to pools cache so /pools/live gets a cache HIT
+        active_articles = await repo.get_active()
+        if active_articles:
+            pools_col = mongodb.get_collection("pools")
+            today = start.strftime("%Y-%m-%d")
+            for market in [None, "US", "CN"]:
+                await pools_col.update_one(
+                    {"type": "news", "date": today, "market": market or "US"},
+                    {
+                        "$set": {
+                            "items": active_articles,
+                            "cached_at": datetime.now(timezone.utc).isoformat(),
+                        }
+                    },
+                    upsert=True,
+                )
+            log.info("Synced %d news articles to pools cache", len(active_articles))
+
         # Fire-and-forget graph write for active news entities (graceful degradation)
         from src.graph.writer import try_ingest_news_batch
 
-        active_articles = await repo.get_active()
         try_ingest_news_batch(active_articles)
     except Exception as e:
         duration = (datetime.now(timezone.utc) - start).total_seconds()
@@ -160,6 +177,27 @@ async def run_value_pipeline() -> None:
                     "created_at": start.isoformat(),
                 }
             )
+            # Sync active values to pools cache
+            active_values = await repo.get_active(market=market)
+            if active_values:
+                pools_col = mongodb.get_collection("pools")
+                today = start.strftime("%Y-%m-%d")
+                await pools_col.update_one(
+                    {"type": "value", "date": today, "market": market},
+                    {
+                        "$set": {
+                            "items": active_values,
+                            "cached_at": datetime.now(timezone.utc).isoformat(),
+                        }
+                    },
+                    upsert=True,
+                )
+                log.info(
+                    "Synced %d value entities to pools cache for market=%s",
+                    len(active_values),
+                    market,
+                )
+
             log.info(
                 "Value pipeline market=%s done in %.1fs — %d inserted, %d merged, %d rescored",
                 market,

--- a/backend/src/main.py
+++ b/backend/src/main.py
@@ -26,6 +26,37 @@ async def _periodic_health_check():
         await registry.health_check()
 
 
+async def _run_pipelines_once():
+    """Pre-populate news + value pools on startup."""
+    from src.cron.scheduler import run_news_pipeline, run_value_pipeline
+
+    try:
+        await run_news_pipeline()
+    except Exception as e:
+        log.warning("Startup news pipeline failed (non-fatal): %s", e)
+    try:
+        await run_value_pipeline()
+    except Exception as e:
+        log.warning("Startup value pipeline failed (non-fatal): %s", e)
+
+
+async def _periodic_pipeline_refresh():
+    """Re-run pipelines every 2 hours to keep pools fresh."""
+    from src.cron.scheduler import run_news_pipeline, run_value_pipeline
+
+    while True:
+        await asyncio.sleep(settings.news_cron_interval_hours * 3600)
+        log.info("Cron: refreshing news + value pipelines")
+        try:
+            await run_news_pipeline()
+        except Exception as e:
+            log.warning("Cron news pipeline failed: %s", e)
+        try:
+            await run_value_pipeline()
+        except Exception as e:
+            log.warning("Cron value pipeline failed: %s", e)
+
+
 @asynccontextmanager
 async def lifespan(_: FastAPI):  # noqa: ARG001
     log.info("Starting up — connecting to MongoDB")
@@ -60,17 +91,23 @@ async def lifespan(_: FastAPI):  # noqa: ARG001
     except Exception as e:
         log.warning("Graph initialization failed (non-fatal): %s", e)
 
-    # Start periodic SSE health check
+    # Pre-populate pools on startup (non-blocking background task)
+    log.info("Pre-populating news + value pools")
+    prepopulate_task = asyncio.create_task(_run_pipelines_once())
+
+    # Start periodic tasks
     health_task = asyncio.create_task(_periodic_health_check())
+    cron_task = asyncio.create_task(_periodic_pipeline_refresh())
 
     yield
 
     log.info("Shutting down")
-    health_task.cancel()
-    try:
-        await health_task
-    except asyncio.CancelledError:
-        pass
+    for task in [health_task, cron_task, prepopulate_task]:
+        task.cancel()
+        try:
+            await task
+        except asyncio.CancelledError:
+            pass
 
     try:
         await close_graph_services()

--- a/backend/src/pipelines/base.py
+++ b/backend/src/pipelines/base.py
@@ -47,15 +47,17 @@ class PoolPipeline:
         touched: set[str] = set()
         for raw in raw_items:
             pr = await self.process.process(raw, existing)
-            sr: ScoreResult = self.score.score(raw)
 
             if pr.action == "merge" and pr.entity_id in existing_by_id:
-                # Merge: preserve existing fields, overlay raw + new scores
                 entity = {**existing_by_id[pr.entity_id], **raw}
             else:
                 entity = {**raw}
 
             entity["id"] = pr.entity_id
+            entity["last_seen_at"] = datetime.now(timezone.utc).isoformat()
+
+            # Score after setting last_seen_at (freshness depends on it)
+            sr: ScoreResult = self.score.score(entity)
             entity["score"] = sr.score
             entity["score_factors"] = sr.factors
             entity["status"] = (

--- a/backend/src/pipelines/value/fetch.py
+++ b/backend/src/pipelines/value/fetch.py
@@ -1,4 +1,6 @@
-"""Value fetching — Yahoo Finance placeholder."""
+"""Value fetching — Yahoo Finance via data_sources."""
+
+import asyncio
 
 from src.core.logger import get_logger
 
@@ -6,8 +8,12 @@ log = get_logger("pipelines.value.fetch")
 
 
 class YahooFinanceFetch:
-    """Placeholder. Returns empty list until Yahoo Finance API integration is available."""
+    """Fetch value stocks from Yahoo Finance via the existing data_sources helper."""
 
-    async def fetch(self, market: str) -> list[dict]:
-        log.info("YahooFinanceFetch.fetch(market=%s) — placeholder", market)
-        return []
+    async def fetch(self, market: str | None) -> list[dict]:
+        from src.services.data_sources import fetch_real_stocks
+
+        log.info("YahooFinanceFetch.fetch(market=%s)", market)
+        stocks = await asyncio.to_thread(fetch_real_stocks)
+        log.info("YahooFinanceFetch: %d stocks fetched", len(stocks))
+        return stocks

--- a/backend/src/services/thinking_service.py
+++ b/backend/src/services/thinking_service.py
@@ -310,6 +310,22 @@ async def run_layer_streaming(
             _push("layer_complete", {"layer": layer, "reason": "no effects"})
             return _empty_layer_result("Thinker produced no effects")
 
+        # Remap batch IDs → streaming IDs so edges reference frontend node IDs.
+        # Both lists iterate effects_raw in order, so index alignment works.
+        batch_to_stream: dict[str, str] = {}
+        for idx, node in enumerate(effect_nodes):
+            stream_id = index_to_id.get(idx)
+            if stream_id:
+                batch_to_stream[node["id"]] = stream_id
+                node["id"] = stream_id  # update node ID too
+
+        for edge in effect_edges:
+            edge["source"] = batch_to_stream.get(edge["source"], edge["source"])
+            edge["target"] = batch_to_stream.get(edge["target"], edge["target"])
+        for edge in fetch_edges:
+            edge["source"] = batch_to_stream.get(edge["source"], edge["source"])
+            edge["target"] = batch_to_stream.get(edge["target"], edge["target"])
+
         all_edges = list(effect_edges) + list(fetch_edges)
 
         # Push edges from thinker

--- a/backend/tests/pipelines/value/test_fetch.py
+++ b/backend/tests/pipelines/value/test_fetch.py
@@ -5,8 +5,13 @@ from src.pipelines.value.fetch import YahooFinanceFetch
 class TestYahooFinanceFetch:
     @pytest.mark.asyncio
     async def test_fetch_returns_list(self):
-        assert isinstance(await YahooFinanceFetch().fetch("US"), list)
+        result = await YahooFinanceFetch().fetch("US")
+        assert isinstance(result, list)
 
     @pytest.mark.asyncio
-    async def test_fetch_returns_empty(self):
-        assert len(await YahooFinanceFetch().fetch("CN")) == 0
+    async def test_fetch_returns_stocks_with_required_fields(self):
+        result = await YahooFinanceFetch().fetch("US")
+        for stock in result:
+            assert "id" in stock
+            assert "ticker" in stock
+            assert "price" in stock

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -12,93 +12,16 @@ import {
 import "@xyflow/react/dist/style.css";
 import { graphApi, type PoolItem } from "./services/api";
 import { createLogger } from "./lib/logger";
-import { TYPE_COLORS, DIR_ICON, type Convergence } from "./lib/graph-builder";
+import { TYPE_COLORS, type Convergence } from "./lib/graph-builder";
 import { AgentFace } from "./components/AgentFace";
 import { ThinkingView } from "./components/ThinkingView";
+import { PoolCard } from "./components/PoolCard";
 
 const log = createLogger("app");
 
 function todayDate(): string {
   const d = new Date();
   return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}-${String(d.getDate()).padStart(2, "0")}`;
-}
-
-const DIR_COLOR: Record<string, string> = {
-  bullish: "#22c55e",
-  bearish: "#ef4444",
-  neutral: "#6b7394",
-};
-
-/* ─── Pool Card ─── */
-function PoolCard({
-  item,
-  side,
-  selected,
-  onSelect,
-  floating,
-}: {
-  item: PoolItem;
-  side: "left" | "right";
-  selected: boolean;
-  onSelect: (id: string) => void;
-  floating: boolean;
-}) {
-  const color = TYPE_COLORS[item.type] ?? "#6b7394";
-  const dir = DIR_ICON[item.direction] ?? "";
-  const dirColor = DIR_COLOR[item.direction] ?? "#6b7394";
-  const title = item.title ?? `${item.ticker} — $${item.price}`;
-  const [anim] = useState(() => ({
-    delay: `${Math.random() * 3}s`,
-    duration: `${3 + Math.random() * 2}s`,
-  }));
-  const isFloating = floating && !selected;
-  const edge = `1px solid ${selected ? color : "rgba(255,255,255,0.06)"}`;
-  const accent = `3px solid ${color}`;
-
-  return (
-    <button
-      onClick={() => onSelect(item.id)}
-      className="w-full text-left"
-      style={{
-        background: selected
-          ? "rgba(255,255,255,0.08)"
-          : "rgba(15, 20, 35, 0.7)",
-        backdropFilter: "blur(8px)",
-        borderTop: edge,
-        borderBottom: edge,
-        borderLeft: side === "left" ? accent : edge,
-        borderRight: side === "right" ? accent : edge,
-        borderRadius: 10,
-        padding: "10px 14px",
-        boxShadow: selected ? `0 0 20px ${color}30` : "none",
-        transition: "border-color 0.3s, box-shadow 0.3s, background 0.3s",
-        animation: isFloating
-          ? `float ${anim.duration} ease-in-out ${anim.delay} infinite`
-          : "none",
-      }}
-    >
-      <div className="flex items-center justify-between mb-1">
-        <span className="text-xs font-medium" style={{ color }}>
-          {item.type === "news_event" ? item.source : item.ticker}
-        </span>
-        <span className="text-xs" style={{ color: dirColor }}>
-          {dir} {item.confidence}%
-        </span>
-      </div>
-      <p className="text-xs text-text leading-snug">{title}</p>
-      <p className="text-[10px] text-text-muted mt-1 leading-snug">
-        {item.summary}
-      </p>
-      {item.discount_pct && (
-        <span
-          className="text-[10px] mt-1 inline-block px-1.5 py-0.5 rounded"
-          style={{ background: "rgba(34,197,94,0.1)", color: "#22c55e" }}
-        >
-          {item.discount_pct}% off 52w
-        </span>
-      )}
-    </button>
-  );
 }
 
 /* ─── Main App ─── */
@@ -121,6 +44,13 @@ function App() {
   const [loading, setLoading] = useState(true);
 
   useEffect(() => {
+    // URL hash shortcut: #session=<id> loads a session directly
+    const match = window.location.hash.match(/session=([a-f0-9]+)/);
+    if (match) {
+      setThinkingSessionId(match[1]);
+      setPhase("thinking");
+    }
+
     const date = todayDate();
     log.info("Loading live pools for", date);
     graphApi

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -32,25 +32,20 @@ function App() {
   const [selectedValues, setSelectedValues] = useState<Set<string>>(new Set());
   const [nodes, setNodes, onNodesChange] = useNodesState<RFNode>([]);
   const [edges, setEdges, onEdgesChange] = useEdgesState<RFEdge>([]);
+  // URL hash shortcut: #session=<id> loads a session directly
+  const hashMatch = window.location.hash.match(/session=([a-f0-9]+)/);
   const [phase, setPhase] = useState<
     "pools" | "connecting" | "done" | "thinking"
-  >("pools");
+  >(hashMatch ? "thinking" : "pools");
   const [convergences, setConvergences] = useState<Convergence[]>([]);
   const connectingRef = useRef(false);
   const rfInstance = useRef<ReactFlowInstance | null>(null);
   const [thinkingSessionId, setThinkingSessionId] = useState<string | null>(
-    null,
+    hashMatch ? hashMatch[1] : null,
   );
   const [loading, setLoading] = useState(true);
 
   useEffect(() => {
-    // URL hash shortcut: #session=<id> loads a session directly
-    const match = window.location.hash.match(/session=([a-f0-9]+)/);
-    if (match) {
-      setThinkingSessionId(match[1]);
-      setPhase("thinking");
-    }
-
     const date = todayDate();
     log.info("Loading live pools for", date);
     graphApi

--- a/frontend/src/components/CausalChain.tsx
+++ b/frontend/src/components/CausalChain.tsx
@@ -1,0 +1,123 @@
+/**
+ * CausalChain — vertical mini-flowchart showing the thinking path
+ * from news → effects → opportunity. Rendered inside the detail panel.
+ */
+import type { ThinkingNode, ThinkingSession } from "../types/thinking";
+import { LAYER_COLORS } from "../lib/thinking-graph-builder";
+
+function traceChain(nodeId: string, session: ThinkingSession): ThinkingNode[] {
+  const nodeMap = new Map(session.nodes.map((n) => [n.id, n]));
+  const parentMap: Record<string, string[]> = {};
+  for (const e of session.edges) {
+    (parentMap[e.target] ??= []).push(e.source);
+  }
+
+  // BFS backward from the node to all roots
+  const visited = new Set<string>();
+  const chain: ThinkingNode[] = [];
+  const queue = [nodeId];
+  visited.add(nodeId);
+
+  while (queue.length > 0) {
+    const current = queue.shift()!;
+    const node = nodeMap.get(current);
+    if (node) chain.push(node);
+    for (const parent of parentMap[current] ?? []) {
+      if (!visited.has(parent)) {
+        visited.add(parent);
+        queue.push(parent);
+      }
+    }
+  }
+
+  // Sort by layer ascending so news comes first
+  chain.sort((a, b) => a.layer - b.layer);
+  return chain;
+}
+
+export function CausalChain({
+  node,
+  session,
+}: {
+  node: ThinkingNode;
+  session: ThinkingSession;
+}) {
+  const chain = traceChain(node.id, session);
+  if (chain.length <= 1) return null;
+
+  return (
+    <div className="causal-chain">
+      <div className="causal-chain__label">Thinking Chain</div>
+      <div className="causal-chain__flow">
+        {chain.map((n, i) => {
+          const color =
+            n.type === "opportunity"
+              ? "#22c55e"
+              : LAYER_COLORS[Math.min(n.layer, LAYER_COLORS.length - 1)];
+          const isLast = i === chain.length - 1;
+          return (
+            <div key={n.id} className="causal-chain__step">
+              <div
+                className="causal-chain__card"
+                style={{
+                  borderColor: `${color}40`,
+                  background:
+                    n.type === "opportunity"
+                      ? "rgba(34, 197, 94, 0.08)"
+                      : "rgba(15, 20, 35, 0.6)",
+                }}
+              >
+                <div className="causal-chain__header">
+                  <span
+                    className="causal-chain__dot"
+                    style={{ background: color, boxShadow: `0 0 6px ${color}` }}
+                  />
+                  <span className="causal-chain__type" style={{ color }}>
+                    {n.type === "news"
+                      ? "NEWS"
+                      : n.type === "opportunity"
+                        ? "OPPORTUNITY"
+                        : `L${n.layer} EFFECT`}
+                  </span>
+                  {typeof (
+                    n.metadata?.confidence ?? n.metadata?.convergence_score
+                  ) === "number" && (
+                    <span className="causal-chain__conf">
+                      {Math.round(
+                        (n.metadata?.confidence ??
+                          n.metadata?.convergence_score) as number,
+                      )}
+                      %
+                    </span>
+                  )}
+                </div>
+                <div className="causal-chain__text">{n.content}</div>
+              </div>
+              {!isLast && (
+                <div className="causal-chain__arrow">
+                  <svg width="12" height="20" viewBox="0 0 12 20">
+                    <line
+                      x1="6"
+                      y1="0"
+                      x2="6"
+                      y2="14"
+                      stroke={color}
+                      strokeWidth="1"
+                      strokeDasharray="3 2"
+                      opacity="0.4"
+                    />
+                    <polygon
+                      points="3,12 6,18 9,12"
+                      fill={color}
+                      opacity="0.5"
+                    />
+                  </svg>
+                </div>
+              )}
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/OpportunityStrip.tsx
+++ b/frontend/src/components/OpportunityStrip.tsx
@@ -1,0 +1,77 @@
+/**
+ * OpportunityStrip — thin top bar showing green pips for each opportunity.
+ * Expands on hover to reveal full list with ticker, conviction, and summary.
+ * Hovering an item highlights the corresponding node in the graph.
+ */
+import { useState } from "react";
+import type { ThinkingSession } from "../types/thinking";
+
+export function OpportunityStrip({
+  session,
+  onHighlight,
+  onClearHighlight,
+}: {
+  session: ThinkingSession | null;
+  onHighlight: (nodeId: string) => void;
+  onClearHighlight: () => void;
+}) {
+  const [expanded, setExpanded] = useState(false);
+
+  if (!session) return null;
+  const opps = session.nodes.filter((n) => n.type === "opportunity");
+  if (opps.length === 0) return null;
+
+  return (
+    <div
+      className="opp-strip"
+      data-expanded={expanded}
+      onMouseEnter={() => setExpanded(true)}
+      onMouseLeave={() => {
+        setExpanded(false);
+        onClearHighlight();
+      }}
+    >
+      {/* Collapsed: just green pips */}
+      <div className="opp-strip__bar">
+        <span className="opp-strip__label">
+          {opps.length} opportunit{opps.length === 1 ? "y" : "ies"}
+        </span>
+        <div className="opp-strip__pips">
+          {opps.map((o) => (
+            <span key={o.id} className="opp-strip__pip" />
+          ))}
+        </div>
+      </div>
+
+      {/* Expanded: full list */}
+      {expanded && (
+        <div className="opp-strip__list">
+          {opps.map((o) => {
+            const conf =
+              (o.metadata?.convergence_score as number) ??
+              (o.metadata?.confidence as number) ??
+              0;
+            const ticker = o.content.split("—")[0]?.trim() ?? o.content;
+            return (
+              <div
+                key={o.id}
+                className="opp-strip__item"
+                onMouseEnter={() => onHighlight(o.id)}
+                onMouseLeave={() => onClearHighlight()}
+              >
+                <div className="opp-strip__item-header">
+                  <span className="opp-strip__ticker">{ticker}</span>
+                  <span className="opp-strip__conv">{Math.round(conf)}%</span>
+                </div>
+                <div className="opp-strip__reasoning">
+                  {o.reasoning?.slice(0, 120) || "No reasoning available"}
+                  {(o.reasoning?.length ?? 0) > 120 ? "..." : ""}
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/OpportunityStrip.tsx
+++ b/frontend/src/components/OpportunityStrip.tsx
@@ -1,18 +1,22 @@
 /**
  * OpportunityStrip — thin top bar showing green pips for each opportunity.
  * Expands on hover to reveal full list with ticker, conviction, and summary.
- * Hovering an item highlights the corresponding node in the graph.
+ * Click to pin (same as clicking opportunity node in graph). Hover to preview.
  */
 import { useState } from "react";
 import type { ThinkingSession } from "../types/thinking";
 
 export function OpportunityStrip({
   session,
+  pinnedNodeId,
   onHighlight,
+  onPin,
   onClearHighlight,
 }: {
   session: ThinkingSession | null;
+  pinnedNodeId: string | null;
   onHighlight: (nodeId: string) => void;
+  onPin: (nodeId: string) => void;
   onClearHighlight: () => void;
 }) {
   const [expanded, setExpanded] = useState(false);
@@ -28,7 +32,8 @@ export function OpportunityStrip({
       onMouseEnter={() => setExpanded(true)}
       onMouseLeave={() => {
         setExpanded(false);
-        onClearHighlight();
+        // Only clear highlight if nothing is pinned
+        if (!pinnedNodeId) onClearHighlight();
       }}
     >
       {/* Collapsed: just green pips */}
@@ -38,7 +43,11 @@ export function OpportunityStrip({
         </span>
         <div className="opp-strip__pips">
           {opps.map((o) => (
-            <span key={o.id} className="opp-strip__pip" />
+            <span
+              key={o.id}
+              className="opp-strip__pip"
+              data-pinned={pinnedNodeId === o.id}
+            />
           ))}
         </div>
       </div>
@@ -52,16 +61,25 @@ export function OpportunityStrip({
               (o.metadata?.confidence as number) ??
               0;
             const ticker = o.content.split("—")[0]?.trim() ?? o.content;
+            const isPinned = pinnedNodeId === o.id;
             return (
               <div
                 key={o.id}
                 className="opp-strip__item"
-                onMouseEnter={() => onHighlight(o.id)}
-                onMouseLeave={() => onClearHighlight()}
+                data-pinned={isPinned}
+                onClick={() => onPin(o.id)}
+                onMouseEnter={() => {
+                  if (!pinnedNodeId) onHighlight(o.id);
+                }}
+                onMouseLeave={() => {
+                  if (!pinnedNodeId) onClearHighlight();
+                }}
               >
                 <div className="opp-strip__item-header">
                   <span className="opp-strip__ticker">{ticker}</span>
-                  <span className="opp-strip__conv">{Math.round(conf)}%</span>
+                  <span className="opp-strip__conv">
+                    {Math.round(conf)}%{isPinned && " \u2022"}
+                  </span>
                 </div>
                 <div className="opp-strip__reasoning">
                   {o.reasoning?.slice(0, 120) || "No reasoning available"}

--- a/frontend/src/components/PoolCard.tsx
+++ b/frontend/src/components/PoolCard.tsx
@@ -1,0 +1,80 @@
+import { useState } from "react";
+import type { PoolItem } from "../services/api";
+import { TYPE_COLORS, DIR_ICON } from "../lib/graph-builder";
+
+const DIR_COLOR: Record<string, string> = {
+  bullish: "#22c55e",
+  bearish: "#ef4444",
+  neutral: "#6b7394",
+};
+
+export function PoolCard({
+  item,
+  side,
+  selected,
+  onSelect,
+  floating,
+}: {
+  item: PoolItem;
+  side: "left" | "right";
+  selected: boolean;
+  onSelect: (id: string) => void;
+  floating: boolean;
+}) {
+  const color = TYPE_COLORS[item.type] ?? "#6b7394";
+  const dir = DIR_ICON[item.direction] ?? "";
+  const dirColor = DIR_COLOR[item.direction] ?? "#6b7394";
+  const title = item.title ?? `${item.ticker} — $${item.price}`;
+  const [anim] = useState(() => ({
+    delay: `${Math.random() * 3}s`,
+    duration: `${3 + Math.random() * 2}s`,
+  }));
+  const isFloating = floating && !selected;
+  const edge = `1px solid ${selected ? color : "rgba(255,255,255,0.06)"}`;
+  const accent = `3px solid ${color}`;
+
+  return (
+    <button
+      onClick={() => onSelect(item.id)}
+      className="w-full text-left"
+      style={{
+        background: selected
+          ? "rgba(255,255,255,0.08)"
+          : "rgba(15, 20, 35, 0.7)",
+        backdropFilter: "blur(8px)",
+        borderTop: edge,
+        borderBottom: edge,
+        borderLeft: side === "left" ? accent : edge,
+        borderRight: side === "right" ? accent : edge,
+        borderRadius: 10,
+        padding: "10px 14px",
+        boxShadow: selected ? `0 0 20px ${color}30` : "none",
+        transition: "border-color 0.3s, box-shadow 0.3s, background 0.3s",
+        animation: isFloating
+          ? `float ${anim.duration} ease-in-out ${anim.delay} infinite`
+          : "none",
+      }}
+    >
+      <div className="flex items-center justify-between mb-1">
+        <span className="text-xs font-medium" style={{ color }}>
+          {item.type === "news_event" ? item.source : item.ticker}
+        </span>
+        <span className="text-xs" style={{ color: dirColor }}>
+          {dir} {item.confidence}%
+        </span>
+      </div>
+      <p className="text-xs text-text leading-snug">{title}</p>
+      <p className="text-[10px] text-text-muted mt-1 leading-snug">
+        {item.summary}
+      </p>
+      {item.discount_pct && (
+        <span
+          className="text-[10px] mt-1 inline-block px-1.5 py-0.5 rounded"
+          style={{ background: "rgba(34,197,94,0.1)", color: "#22c55e" }}
+        >
+          {item.discount_pct}% off 52w
+        </span>
+      )}
+    </button>
+  );
+}

--- a/frontend/src/components/StreamingNode.tsx
+++ b/frontend/src/components/StreamingNode.tsx
@@ -21,52 +21,48 @@ function StreamingNodeComponent({ data }: NodeProps) {
   }, []);
 
   const isOpp = d.type === "opportunity";
+  const isNews = d.type === "news";
+  const hasConf =
+    typeof d.confidence === "number" &&
+    !Number.isNaN(d.confidence) &&
+    !d.streaming;
 
   return (
     <div
+      className="nexis-node"
+      data-type={d.type}
+      data-layer={d.layer}
       style={{
         opacity: visible ? 1 : 0,
-        transform: visible ? "scale(1)" : "scale(0.8)",
-        transition: "opacity 400ms ease-out, transform 400ms ease-out",
+        transform: visible ? "scale(1)" : "scale(0.85)",
+        transition: "opacity 350ms ease-out, transform 350ms ease-out",
       }}
     >
       <Handle type="target" position={Position.Top} style={{ opacity: 0 }} />
-      <div
-        style={{
-          fontSize: 11,
-          lineHeight: 1.4,
-          minWidth: 120,
-          maxWidth: 180,
-          padding: "8px 12px",
-        }}
-      >
-        <div
-          style={{
-            overflow: "hidden",
-            display: "-webkit-box",
-            WebkitLineClamp: 3,
-            WebkitBoxOrient: "vertical",
-          }}
-        >
-          {d.label}
-        </div>
-        {d.streaming && (
-          <span
-            className="inline-block w-1.5 h-3 ml-0.5 bg-current animate-pulse"
-            style={{ opacity: 0.6 }}
-          />
-        )}
-        {typeof d.confidence === "number" &&
-          !Number.isNaN(d.confidence) &&
-          !d.streaming && (
-            <div
-              className="mt-1 text-[10px]"
-              style={{ color: isOpp ? "#86efac" : "#9ca3af" }}
-            >
-              {d.confidence}%
-            </div>
+
+      {isOpp ? (
+        /* ─── Opportunity: ticker + conviction front and center ─── */
+        <div className="nexis-node__opp">
+          <div className="nexis-node__opp-label">{d.label}</div>
+          {hasConf && (
+            <div className="nexis-node__opp-conf">{d.confidence}%</div>
           )}
-      </div>
+        </div>
+      ) : (
+        /* ─── News / Effect: compact pill ─── */
+        <div className="nexis-node__body">
+          {/* Type dot */}
+          <span className="nexis-node__dot" />
+          <div className="nexis-node__content">
+            <div className="nexis-node__text">{d.label}</div>
+            {d.streaming && <span className="nexis-node__cursor" />}
+            {hasConf && !isNews && (
+              <span className="nexis-node__conf">{d.confidence}%</span>
+            )}
+          </div>
+        </div>
+      )}
+
       <Handle type="source" position={Position.Bottom} style={{ opacity: 0 }} />
     </div>
   );

--- a/frontend/src/components/StreamingNode.tsx
+++ b/frontend/src/components/StreamingNode.tsx
@@ -47,14 +47,16 @@ function StreamingNodeComponent({ data }: NodeProps) {
             style={{ opacity: 0.6 }}
           />
         )}
-        {d.confidence != null && !d.streaming && (
-          <div
-            className="mt-1 text-[10px]"
-            style={{ color: isOpp ? "#86efac" : "#9ca3af" }}
-          >
-            {d.confidence}% confidence
-          </div>
-        )}
+        {typeof d.confidence === "number" &&
+          !Number.isNaN(d.confidence) &&
+          !d.streaming && (
+            <div
+              className="mt-1 text-[10px]"
+              style={{ color: isOpp ? "#86efac" : "#9ca3af" }}
+            >
+              {d.confidence}% confidence
+            </div>
+          )}
       </div>
       <Handle type="source" position={Position.Bottom} style={{ opacity: 0 }} />
     </div>

--- a/frontend/src/components/StreamingNode.tsx
+++ b/frontend/src/components/StreamingNode.tsx
@@ -33,14 +33,23 @@ function StreamingNodeComponent({ data }: NodeProps) {
       <Handle type="target" position={Position.Top} style={{ opacity: 0 }} />
       <div
         style={{
-          fontSize: 12,
-          lineHeight: 1.5,
-          minWidth: 140,
-          maxWidth: 200,
-          padding: "10px 14px",
+          fontSize: 11,
+          lineHeight: 1.4,
+          minWidth: 120,
+          maxWidth: 180,
+          padding: "8px 12px",
         }}
       >
-        <div>{d.label}</div>
+        <div
+          style={{
+            overflow: "hidden",
+            display: "-webkit-box",
+            WebkitLineClamp: 3,
+            WebkitBoxOrient: "vertical",
+          }}
+        >
+          {d.label}
+        </div>
         {d.streaming && (
           <span
             className="inline-block w-1.5 h-3 ml-0.5 bg-current animate-pulse"
@@ -54,7 +63,7 @@ function StreamingNodeComponent({ data }: NodeProps) {
               className="mt-1 text-[10px]"
               style={{ color: isOpp ? "#86efac" : "#9ca3af" }}
             >
-              {d.confidence}% confidence
+              {d.confidence}%
             </div>
           )}
       </div>

--- a/frontend/src/components/ThinkingPanels.tsx
+++ b/frontend/src/components/ThinkingPanels.tsx
@@ -1,8 +1,9 @@
 /**
- * Extracted UI panels for ThinkingView — spectrum, opportunities banner, node detail.
+ * Extracted UI panels for ThinkingView — node detail with causal chain.
  */
 import type { ThinkingNode, ThinkingSession } from "../types/thinking";
 import { LAYER_COLORS } from "../lib/thinking-graph-builder";
+import { CausalChain } from "./CausalChain";
 
 /* ─── Layer Spectrum ─── */
 export function LayerSpectrum({
@@ -91,11 +92,13 @@ export function OpportunitiesBanner({
 /* ─── Node Detail Panel ─── */
 export function NodeDetailPanel({
   node,
+  session,
   onClose,
   onToggle,
   onRegenerate,
 }: {
   node: ThinkingNode;
+  session: ThinkingSession | null;
   onClose: () => void;
   onToggle: (nodeId: string, selected: boolean) => void;
   onRegenerate?: () => void;
@@ -136,6 +139,7 @@ export function NodeDetailPanel({
           ))}
         </div>
       )}
+      {session && <CausalChain node={node} session={session} />}
       <div className="px-4 py-3 flex flex-col gap-2">
         <button
           onClick={() => onToggle(node.id, !node.selected)}

--- a/frontend/src/components/ThinkingView.tsx
+++ b/frontend/src/components/ThinkingView.tsx
@@ -429,8 +429,12 @@ export function ThinkingView({ sessionId, onReset }: ThinkingViewProps) {
       {/* Opportunity strip — top center, hover to expand */}
       <OpportunityStrip
         session={session}
-        onHighlight={(nodeId) => pinPath(nodeId)}
-        onClearHighlight={() => unpinPath()}
+        pinnedNodeId={pinnedNodeId}
+        onHighlight={pinPath}
+        onPin={(id) => (pinnedNodeId === id ? unpinPath() : pinPath(id))}
+        onClearHighlight={() => {
+          if (!pinnedNodeId) unpinPath();
+        }}
       />
 
       {/* Agent face: only while thinking AND before any effect nodes arrive */}

--- a/frontend/src/components/ThinkingView.tsx
+++ b/frontend/src/components/ThinkingView.tsx
@@ -1,6 +1,6 @@
 /**
- * ThinkingView — the concentric ring graph visualization for thinking sessions.
- * Shows the DAG with ring guides per layer, node detail panel, and controls.
+ * ThinkingView — concentric ring graph visualization for thinking sessions.
+ * SSE handlers extracted to useSSEHandlers hook.
  */
 import { useCallback, useEffect, useRef, useState } from "react";
 import {
@@ -15,12 +15,7 @@ import {
 } from "@xyflow/react";
 import "@xyflow/react/dist/style.css";
 import type { ThinkingSession, ThinkingNode } from "../types/thinking";
-import {
-  buildThinkingGraph,
-  nodeStyle,
-  concentricPosition,
-  LAYER_COLORS,
-} from "../lib/thinking-graph-builder";
+import { buildThinkingGraph, nodeStyle } from "../lib/thinking-graph-builder";
 import {
   LayerSpectrum,
   OpportunitiesBanner,
@@ -32,14 +27,7 @@ import { AgentFace } from "./AgentFace";
 import { usePathHighlight } from "../hooks/usePathHighlight";
 import { StreamingNode } from "./StreamingNode";
 import { useSSESession } from "../hooks/useSSESession";
-import type {
-  SSENodeStart,
-  SSENodeText,
-  SSENodeComplete,
-  SSELayerComplete,
-  SSESessionComplete,
-  SSEEdgesPayload,
-} from "../types/thinking";
+import { useSSEHandlers } from "../hooks/useSSEHandlers";
 
 const log = createLogger("thinking-view");
 
@@ -67,6 +55,22 @@ export function ThinkingView({ sessionId, onReset }: ThinkingViewProps) {
     handleNodeMouseEnter,
     handleNodeMouseLeave,
   } = usePathHighlight({ session, setNodes, setEdges });
+
+  const {
+    handleNodeStart,
+    handleNodeText,
+    handleNodeComplete,
+    handleEdges,
+    handleLayerComplete,
+    handleSessionComplete,
+  } = useSSEHandlers({
+    setNodes,
+    setEdges,
+    setSession,
+    setIsPending,
+    layerNodeCounts,
+    positionMap,
+  });
 
   const savePositions = useCallback((rfNodes: RFNode[]) => {
     for (const n of rfNodes) {
@@ -184,200 +188,6 @@ export function ThinkingView({ sessionId, onReset }: ThinkingViewProps) {
     }
   }, [sessionId, setNodes, setEdges, savePositions]);
 
-  // --- SSE streaming handlers ---
-
-  const handleNodeStart = useCallback(
-    (data: SSENodeStart) => {
-      const { id, layer, type, parent_ids } = data;
-      const count = (layerNodeCounts.current.get(layer) ?? 0) + 1;
-      layerNodeCounts.current.set(layer, count);
-      const idx = count - 1;
-
-      // Re-space existing nodes on this layer
-      setNodes((prev) => {
-        const updated = prev.map((n) => {
-          if (n.data.layer !== layer) return n;
-          const existingIdx = prev
-            .filter((p) => p.data.layer === layer)
-            .indexOf(n);
-          const pos = concentricPosition(layer, existingIdx, count);
-          positionMap.current.set(n.id, pos);
-          return { ...n, position: pos };
-        });
-
-        // Add the new streaming node
-        const pos = concentricPosition(layer, idx, count);
-        positionMap.current.set(id, pos);
-        const newNode: RFNode = {
-          id,
-          type: "streaming",
-          position: pos,
-          data: {
-            label: "",
-            type,
-            layer,
-            selected: true,
-            reasoning: "",
-            streaming: true,
-            parent_ids,
-          },
-          style: nodeStyle(type, true, layer),
-        };
-        return [...updated, newNode];
-      });
-
-      // Also track in session
-      setSession((prev) => {
-        if (!prev) return prev;
-        const newThinkingNode: ThinkingNode = {
-          id,
-          layer,
-          type: type as ThinkingNode["type"],
-          content: "",
-          reasoning: "",
-          sources: [],
-          parents: parent_ids,
-          selected: true,
-          metadata: {},
-        };
-        return {
-          ...prev,
-          nodes: [...prev.nodes, newThinkingNode],
-          current_layer: Math.max(prev.current_layer, layer),
-        };
-      });
-    },
-    [setNodes],
-  );
-
-  const handleNodeText = useCallback(
-    (data: SSENodeText) => {
-      const { id, field, delta } = data;
-      setNodes((prev) =>
-        prev.map((n) => {
-          if (n.id !== id) return n;
-          if (field === "content") {
-            return {
-              ...n,
-              data: { ...n.data, label: (n.data.label ?? "") + delta },
-            };
-          }
-          return {
-            ...n,
-            data: { ...n.data, reasoning: (n.data.reasoning ?? "") + delta },
-          };
-        }),
-      );
-
-      // Keep session in sync
-      setSession((prev) => {
-        if (!prev) return prev;
-        return {
-          ...prev,
-          nodes: prev.nodes.map((n) => {
-            if (n.id !== id) return n;
-            if (field === "content")
-              return { ...n, content: n.content + delta };
-            return { ...n, reasoning: n.reasoning + delta };
-          }),
-        };
-      });
-    },
-    [setNodes],
-  );
-
-  const handleNodeComplete = useCallback(
-    (data: SSENodeComplete) => {
-      const { id, confidence, metadata } = data;
-      setNodes((prev) =>
-        prev.map((n) => {
-          if (n.id !== id) return n;
-          return {
-            ...n,
-            data: { ...n.data, streaming: false, confidence },
-          };
-        }),
-      );
-
-      setSession((prev) => {
-        if (!prev) return prev;
-        return {
-          ...prev,
-          nodes: prev.nodes.map((n) =>
-            n.id !== id
-              ? n
-              : { ...n, metadata: { ...n.metadata, ...metadata, confidence } },
-          ),
-        };
-      });
-    },
-    [setNodes],
-  );
-
-  const handleEdges = useCallback(
-    (payload: SSEEdgesPayload) => {
-      const data = payload.edges;
-      const newEdges: RFEdge[] = data.map((e, i) => {
-        const isMatch = e.relationship === "matches";
-        const isConfirm =
-          e.relationship === "compounds" || e.relationship === "causes";
-        return {
-          id: `sse-e-${Date.now()}-${i}-${e.source}-${e.target}`,
-          source: e.source,
-          target: e.target,
-          label: e.relationship,
-          type: "smoothstep",
-          animated: true,
-          markerEnd: {
-            type: "arrowclosed" as const,
-            color: isMatch
-              ? "rgba(34, 197, 94, 0.6)"
-              : "rgba(255, 255, 255, 0.3)",
-            width: 15,
-            height: 15,
-          },
-          style: {
-            stroke: isMatch
-              ? "rgba(34, 197, 94, 0.4)"
-              : isConfirm
-                ? "rgba(255, 255, 255, 0.2)"
-                : "rgba(107, 115, 148, 0.3)",
-            strokeWidth: isMatch ? 2 : 1.5,
-          },
-          labelStyle: {
-            fill: isMatch ? "#86efac" : "#6b7394",
-            fontSize: 10,
-          },
-        };
-      });
-      setEdges((prev) => [...prev, ...newEdges]);
-
-      // Keep session edges in sync
-      setSession((prev) => {
-        if (!prev) return prev;
-        return { ...prev, edges: [...prev.edges, ...data] };
-      });
-    },
-    [setEdges],
-  );
-
-  const handleLayerComplete = useCallback((data: SSELayerComplete) => {
-    setSession((prev) => {
-      if (!prev) return prev;
-      return { ...prev, current_layer: data.layer };
-    });
-    log.info("Layer", data.layer, "complete:", data.controller.summary);
-  }, []);
-
-  const handleSessionComplete = useCallback((data: SSESessionComplete) => {
-    setSession((prev) => {
-      if (!prev) return prev;
-      return { ...prev, status: data.status as ThinkingSession["status"] };
-    });
-    setIsPending(false);
-    log.info("Session complete:", data.status);
-  }, []);
-
   // Wire SSE hook — active only during "thinking" status
   const { connected } = useSSESession(
     session?.status === "thinking" ? sessionId : null,
@@ -395,6 +205,26 @@ export function ThinkingView({ sessionId, onReset }: ThinkingViewProps) {
 
   const isThinking = session?.status === "thinking" || isPending;
 
+  // Auto-fitView when nodes arrive during SSE streaming or session completes
+  const prevNodeCount = useRef(0);
+  useEffect(() => {
+    const count = nodes.length;
+    // Fit on first batch of nodes and when session completes
+    if (
+      count > 0 &&
+      (prevNodeCount.current === 0 ||
+        session?.status === "complete" ||
+        session?.status === "paused")
+    ) {
+      const delay = prevNodeCount.current === 0 ? 300 : 100;
+      setTimeout(
+        () => rfInstance.current?.fitView({ padding: 0.15, duration: 500 }),
+        delay,
+      );
+    }
+    prevNodeCount.current = count;
+  }, [nodes.length, session?.status]);
+
   // Polling fallback — only when SSE is not connected
   useEffect(() => {
     if (connected || session?.status !== "thinking") return;
@@ -402,11 +232,9 @@ export function ThinkingView({ sessionId, onReset }: ThinkingViewProps) {
     return () => clearInterval(interval);
   }, [connected, session?.status, loadSessionIncremental]);
 
-  // Step to next layer
   const handleStep = useCallback(async () => {
     if (isThinking || !session) return;
     setIsPending(true);
-    log.info("Stepping to layer", session.current_layer + 1);
     try {
       await graphApi.thinkStep(sessionId);
       await loadSessionIncremental();
@@ -416,11 +244,9 @@ export function ThinkingView({ sessionId, onReset }: ThinkingViewProps) {
     setIsPending(false);
   }, [sessionId, session, isThinking, loadSessionIncremental]);
 
-  // Match against value pool
   const handleMatch = useCallback(async () => {
     if (isThinking || !session) return;
     setIsPending(true);
-    log.info("Matching against value pool");
     try {
       await graphApi.matchValues(sessionId);
       await loadSessionIncremental();
@@ -430,18 +256,14 @@ export function ThinkingView({ sessionId, onReset }: ThinkingViewProps) {
     setIsPending(false);
   }, [sessionId, session, isThinking, loadSessionIncremental]);
 
-  // Pane click: useCallback to avoid stale closure in React Flow
   const handlePaneClick = useCallback(() => {
     unpinPath();
     setSelectedNode(null);
   }, [unpinPath]);
 
-  // Fallback: container div click also dismisses if target is the pane itself
-  // (not a node or edge inside the pane — those are handled by onNodeClick)
   const handleContainerClick = useCallback(
     (e: React.MouseEvent<HTMLDivElement>) => {
       const target = e.target as HTMLElement;
-      // Only fire if clicking directly on the pane background, not on nodes/edges/UI
       if (
         target.classList.contains("react-flow__pane") ||
         target.classList.contains("react-flow__renderer")
@@ -453,7 +275,6 @@ export function ThinkingView({ sessionId, onReset }: ThinkingViewProps) {
     [unpinPath],
   );
 
-  // Escape key also clears selectedNode (hook handles unpinPath)
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
       if (e.key === "Escape") setSelectedNode(null);
@@ -462,7 +283,6 @@ export function ThinkingView({ sessionId, onReset }: ThinkingViewProps) {
     return () => window.removeEventListener("keydown", handleKeyDown);
   }, []);
 
-  // Click node: show detail panel. Pin path only for opportunity nodes.
   const handleNodeClick = useCallback(
     async (_: React.MouseEvent, node: RFNode) => {
       if (!session) return;
@@ -480,7 +300,6 @@ export function ThinkingView({ sessionId, onReset }: ThinkingViewProps) {
     [session, pinnedNodeId, unpinPath, pinPath],
   );
 
-  // Toggle node via detail panel
   const handleToggle = useCallback(
     async (nodeId: string, selected: boolean) => {
       try {
@@ -499,39 +318,21 @@ export function ThinkingView({ sessionId, onReset }: ThinkingViewProps) {
     (session?.current_layer ?? 0) < (session?.max_depth ?? 3);
   const canMatch =
     session?.status === "paused" && (session?.current_layer ?? 0) > 0;
-  const maxLayer = Math.max(0, ...(session?.nodes.map((n) => n.layer) ?? [0]));
+  const hasEffectNodes = nodes.some(
+    (n) =>
+      (n.data as Record<string, unknown>).layer !== undefined &&
+      ((n.data as Record<string, unknown>).layer as number) > 0,
+  );
 
   return (
-    <div className="flex-1 relative" onClick={handleContainerClick}>
-      {/* Ring guides — colored concentric circles per layer */}
-      <svg
-        className="absolute inset-0 w-full h-full pointer-events-none z-0"
-        style={{ opacity: 0.2 }}
-      >
-        {Array.from({ length: maxLayer + 2 }, (_, i) => {
-          const r = i * 140;
-          const layerColor = LAYER_COLORS[Math.min(i, LAYER_COLORS.length - 1)];
-          return r > 0 ? (
-            <circle
-              key={i}
-              cx="50%"
-              cy="50%"
-              r={r}
-              fill="none"
-              stroke={layerColor}
-              strokeWidth={1}
-              strokeDasharray="4 8"
-              opacity={0.4}
-            />
-          ) : null;
-        })}
-      </svg>
-
+    <div
+      className="flex-1 relative h-full w-full"
+      onClick={handleContainerClick}
+    >
       <LayerSpectrum session={session} />
 
       {/* Controls bar */}
       <div className="absolute top-4 left-1/2 -translate-x-1/2 z-20 flex items-center gap-3">
-        {/* Status */}
         <div className="glass-card px-4 py-2 flex items-center gap-3">
           <span className="text-xs text-text-muted uppercase tracking-widest">
             Layer {session?.current_layer ?? 0}/{session?.max_depth ?? 3}
@@ -557,7 +358,6 @@ export function ThinkingView({ sessionId, onReset }: ThinkingViewProps) {
           )}
         </div>
 
-        {/* Action buttons */}
         {canStep && (
           <button
             onClick={handleStep}
@@ -603,21 +403,15 @@ export function ThinkingView({ sessionId, onReset }: ThinkingViewProps) {
       <OpportunitiesBanner session={session} />
 
       {/* Agent face: only while thinking AND before any effect nodes arrive */}
-      {isThinking &&
-        !nodes.some(
-          (n) =>
-            (n.data as Record<string, unknown>).layer !== undefined &&
-            ((n.data as Record<string, unknown>).layer as number) > 0,
-        ) && (
-          <div
-            className="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 z-10 pointer-events-none"
-            style={{ opacity: 0.4 }}
-          >
-            <AgentFace size={80} />
-          </div>
-        )}
+      {isThinking && !hasEffectNodes && (
+        <div
+          className="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 z-10 pointer-events-none"
+          style={{ opacity: 0.4 }}
+        >
+          <AgentFace size={80} />
+        </div>
+      )}
 
-      {/* React Flow graph */}
       <ReactFlow
         nodeTypes={nodeTypes}
         nodes={nodes}
@@ -634,8 +428,8 @@ export function ThinkingView({ sessionId, onReset }: ThinkingViewProps) {
           rfInstance.current = instance;
         }}
         fitView
-        fitViewOptions={{ padding: 0.1 }}
-        minZoom={0.2}
+        fitViewOptions={{ padding: 0.15 }}
+        minZoom={0.15}
         maxZoom={2}
         proOptions={{ hideAttribution: true }}
       >

--- a/frontend/src/components/ThinkingView.tsx
+++ b/frontend/src/components/ThinkingView.tsx
@@ -327,6 +327,36 @@ export function ThinkingView({ sessionId, onReset }: ThinkingViewProps) {
       className="flex-1 relative h-full w-full"
       onClick={handleContainerClick}
     >
+      {/* Layer color legend — bottom-left */}
+      <div
+        className="absolute bottom-12 left-4 z-20 flex flex-col gap-1.5"
+        style={{
+          background: "rgba(15, 20, 35, 0.7)",
+          backdropFilter: "blur(8px)",
+          border: "1px solid rgba(255,255,255,0.05)",
+          borderRadius: 8,
+          padding: "8px 10px",
+        }}
+      >
+        {[
+          ["#3b82f6", "News"],
+          ["#8b5cf6", "Effects L1"],
+          ["#f59e0b", "Effects L2"],
+          ["#ef4444", "Effects L3"],
+          ["#22c55e", "Opportunities"],
+        ].map(([color, label]) => (
+          <div key={label} className="flex items-center gap-2">
+            <span
+              className="w-2 h-2 rounded-full"
+              style={{ background: color, boxShadow: `0 0 4px ${color}` }}
+            />
+            <span className="text-[10px]" style={{ color: "#6b7394" }}>
+              {label}
+            </span>
+          </div>
+        ))}
+      </div>
+
       {/* Minimal top-right control cluster */}
       <div className="absolute top-4 right-4 z-20 flex items-center gap-2">
         <div

--- a/frontend/src/components/ThinkingView.tsx
+++ b/frontend/src/components/ThinkingView.tsx
@@ -602,15 +602,20 @@ export function ThinkingView({ sessionId, onReset }: ThinkingViewProps) {
 
       <OpportunitiesBanner session={session} />
 
-      {/* Agent face during thinking */}
-      {isThinking && (
-        <div
-          className="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 z-10 pointer-events-none"
-          style={{ opacity: 0.4 }}
-        >
-          <AgentFace size={80} />
-        </div>
-      )}
+      {/* Agent face: only while thinking AND before any effect nodes arrive */}
+      {isThinking &&
+        !nodes.some(
+          (n) =>
+            (n.data as Record<string, unknown>).layer !== undefined &&
+            ((n.data as Record<string, unknown>).layer as number) > 0,
+        ) && (
+          <div
+            className="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 z-10 pointer-events-none"
+            style={{ opacity: 0.4 }}
+          >
+            <AgentFace size={80} />
+          </div>
+        )}
 
       {/* React Flow graph */}
       <ReactFlow

--- a/frontend/src/components/ThinkingView.tsx
+++ b/frontend/src/components/ThinkingView.tsx
@@ -17,6 +17,7 @@ import "@xyflow/react/dist/style.css";
 import type { ThinkingSession, ThinkingNode } from "../types/thinking";
 import { buildThinkingGraph, nodeStyle } from "../lib/thinking-graph-builder";
 import { NodeDetailPanel } from "./ThinkingPanels";
+import { OpportunityStrip } from "./OpportunityStrip";
 import { graphApi } from "../services/api";
 import { createLogger } from "../lib/logger";
 import { AgentFace } from "./AgentFace";
@@ -425,6 +426,13 @@ export function ThinkingView({ sessionId, onReset }: ThinkingViewProps) {
         </button>
       </div>
 
+      {/* Opportunity strip — top center, hover to expand */}
+      <OpportunityStrip
+        session={session}
+        onHighlight={(nodeId) => pinPath(nodeId)}
+        onClearHighlight={() => unpinPath()}
+      />
+
       {/* Agent face: only while thinking AND before any effect nodes arrive */}
       {isThinking && !hasEffectNodes && (
         <div
@@ -463,6 +471,7 @@ export function ThinkingView({ sessionId, onReset }: ThinkingViewProps) {
       {selectedNode && (
         <NodeDetailPanel
           node={selectedNode}
+          session={session}
           onClose={() => setSelectedNode(null)}
           onToggle={handleToggle}
           onRegenerate={

--- a/frontend/src/components/ThinkingView.tsx
+++ b/frontend/src/components/ThinkingView.tsx
@@ -16,11 +16,7 @@ import {
 import "@xyflow/react/dist/style.css";
 import type { ThinkingSession, ThinkingNode } from "../types/thinking";
 import { buildThinkingGraph, nodeStyle } from "../lib/thinking-graph-builder";
-import {
-  LayerSpectrum,
-  OpportunitiesBanner,
-  NodeDetailPanel,
-} from "./ThinkingPanels";
+import { NodeDetailPanel } from "./ThinkingPanels";
 import { graphApi } from "../services/api";
 import { createLogger } from "../lib/logger";
 import { AgentFace } from "./AgentFace";
@@ -331,78 +327,73 @@ export function ThinkingView({ sessionId, onReset }: ThinkingViewProps) {
       className="flex-1 relative h-full w-full"
       onClick={handleContainerClick}
     >
-      <LayerSpectrum session={session} />
-
-      {/* Controls bar */}
-      <div className="absolute top-4 left-1/2 -translate-x-1/2 z-20 flex items-center gap-3">
-        <div className="glass-card px-4 py-2 flex items-center gap-3">
-          <span className="text-xs text-text-muted uppercase tracking-widest">
-            Layer {session?.current_layer ?? 0}/{session?.max_depth ?? 3}
+      {/* Minimal top-right control cluster */}
+      <div className="absolute top-4 right-4 z-20 flex items-center gap-2">
+        <div
+          className="flex items-center gap-2 px-3 py-1.5 rounded-lg"
+          style={{
+            background: "rgba(15, 20, 35, 0.8)",
+            backdropFilter: "blur(12px)",
+            border: "1px solid rgba(255,255,255,0.06)",
+          }}
+        >
+          <span className="text-[11px] font-mono" style={{ color: "#6b7394" }}>
+            {session?.current_layer ?? 0}/{session?.max_depth ?? 3}
           </span>
           {isThinking && (
             <span
-              className="flex items-center gap-1.5 text-xs"
-              style={{ color: "#f97316" }}
-            >
-              <span className="w-2 h-2 rounded-full bg-orange-500 animate-pulse" />
-              Thinking...
-            </span>
+              className="w-1.5 h-1.5 rounded-full animate-pulse"
+              style={{ background: "#f97316" }}
+            />
           )}
           {session?.status === "complete" && (
-            <span className="text-xs" style={{ color: "#22c55e" }}>
-              Complete
-            </span>
-          )}
-          {session?.status === "error" && (
-            <span className="text-xs" style={{ color: "#ef4444" }}>
-              Error: {session.error}
-            </span>
+            <span
+              className="w-1.5 h-1.5 rounded-full"
+              style={{ background: "#22c55e" }}
+            />
           )}
         </div>
-
         {canStep && (
           <button
             onClick={handleStep}
             disabled={isThinking}
-            className="px-4 py-2 rounded-lg text-xs font-medium tracking-wide transition-all"
+            className="px-3 py-1.5 rounded-lg text-[11px] font-medium transition-all"
             style={{
-              background: "rgba(249, 115, 22, 0.12)",
+              background: "rgba(249, 115, 22, 0.1)",
               color: "#f97316",
-              border: "1px solid rgba(249, 115, 22, 0.2)",
-              opacity: isThinking ? 0.5 : 1,
+              border: "1px solid rgba(249, 115, 22, 0.15)",
+              opacity: isThinking ? 0.4 : 1,
             }}
           >
-            Think Deeper
+            Deeper
           </button>
         )}
         {canMatch && (
           <button
             onClick={handleMatch}
             disabled={isThinking}
-            className="px-4 py-2 rounded-lg text-xs font-medium tracking-wide transition-all"
+            className="px-3 py-1.5 rounded-lg text-[11px] font-medium transition-all"
             style={{
-              background: "rgba(34, 197, 94, 0.12)",
+              background: "rgba(34, 197, 94, 0.1)",
               color: "#22c55e",
-              border: "1px solid rgba(34, 197, 94, 0.2)",
-              opacity: isThinking ? 0.5 : 1,
+              border: "1px solid rgba(34, 197, 94, 0.15)",
+              opacity: isThinking ? 0.4 : 1,
             }}
           >
-            Find Opportunities
+            Match
           </button>
         )}
         <button
           onClick={onReset}
-          className="px-3 py-2 rounded-lg text-xs text-text-muted hover:text-text transition-colors"
+          className="px-2.5 py-1.5 rounded-lg text-[11px] text-text-muted hover:text-text transition-colors"
           style={{
             background: "rgba(255,255,255,0.03)",
-            border: "1px solid rgba(255,255,255,0.06)",
+            border: "1px solid rgba(255,255,255,0.05)",
           }}
         >
           Reset
         </button>
       </div>
-
-      <OpportunitiesBanner session={session} />
 
       {/* Agent face: only while thinking AND before any effect nodes arrive */}
       {isThinking && !hasEffectNodes && (

--- a/frontend/src/components/ThinkingView.tsx
+++ b/frontend/src/components/ThinkingView.tsx
@@ -61,6 +61,7 @@ export function ThinkingView({ sessionId, onReset }: ThinkingViewProps) {
     handleNodeText,
     handleNodeComplete,
     handleEdges,
+    handleOpportunity,
     handleLayerComplete,
     handleSessionComplete,
   } = useSSEHandlers({
@@ -196,6 +197,7 @@ export function ThinkingView({ sessionId, onReset }: ThinkingViewProps) {
       onNodeText: handleNodeText,
       onNodeComplete: handleNodeComplete,
       onEdges: handleEdges,
+      onOpportunity: handleOpportunity,
       onLayerComplete: handleLayerComplete,
       onSessionComplete: handleSessionComplete,
       onError: (err) =>

--- a/frontend/src/hooks/useSSEHandlers.ts
+++ b/frontend/src/hooks/useSSEHandlers.ts
@@ -2,7 +2,7 @@
  * useSSEHandlers — SSE event handlers for ThinkingView streaming.
  * Manages node/edge mutations in response to SSE events from the thinking pipeline.
  */
-import { useCallback } from "react";
+import { useCallback, useRef } from "react";
 import type { Node as RFNode, Edge as RFEdge } from "@xyflow/react";
 import type {
   ThinkingNode,
@@ -206,6 +206,9 @@ export function useSSEHandlers({
     [setEdges, setSession],
   );
 
+  // Separate counter for opportunity nodes — they go on their own outer ring
+  const oppCount = useRef(0);
+
   const handleOpportunity = useCallback(
     (data: Record<string, unknown>) => {
       const opp = data as {
@@ -217,30 +220,48 @@ export function useSSEHandlers({
         confidence: number;
         parents: string[];
       };
-      const layer = opp.layer ?? 0;
-      const count = (layerNodeCounts.current.get(layer) ?? 0) + 1;
-      layerNodeCounts.current.set(layer, count);
+      // Place opportunities on a dedicated outer ring, not mixed with effects
+      const maxEffectLayer = Math.max(
+        ...Array.from(layerNodeCounts.current.keys()),
+        1,
+      );
+      const oppRing = maxEffectLayer + 1;
+      oppCount.current += 1;
+      const total = oppCount.current;
 
-      const pos = concentricPosition(layer, count - 1, count);
-      positionMap.current.set(opp.id, pos);
+      // Single setNodes: re-space existing opps + add the new one
+      setNodes((prev) => {
+        const updated = prev.map((n) => {
+          if (n.data.type !== "opportunity") return n;
+          const existingIdx = prev
+            .filter((p) => p.data.type === "opportunity")
+            .indexOf(n);
+          const newPos = concentricPosition(oppRing, existingIdx, total);
+          positionMap.current.set(n.id, newPos);
+          return { ...n, position: newPos };
+        });
 
-      setNodes((prev) => [
-        ...prev,
-        {
-          id: opp.id,
-          type: "streaming",
-          position: pos,
-          data: {
-            label: opp.content,
-            type: "opportunity",
-            layer,
-            selected: true,
-            reasoning: opp.reasoning,
-            confidence: opp.confidence,
+        const pos = concentricPosition(oppRing, total - 1, total);
+        positionMap.current.set(opp.id, pos);
+
+        return [
+          ...updated,
+          {
+            id: opp.id,
+            type: "streaming",
+            position: pos,
+            data: {
+              label: opp.content,
+              type: "opportunity",
+              layer: opp.layer,
+              selected: true,
+              reasoning: opp.reasoning,
+              confidence: opp.confidence,
+            },
+            style: nodeStyle("opportunity", true, opp.layer),
           },
-          style: nodeStyle("opportunity", true, layer),
-        },
-      ]);
+        ];
+      });
 
       setSession((prev) => {
         if (!prev) return prev;
@@ -250,7 +271,7 @@ export function useSSEHandlers({
             ...prev.nodes,
             {
               id: opp.id,
-              layer,
+              layer: opp.layer,
               type: "opportunity" as const,
               content: opp.content,
               reasoning: opp.reasoning ?? "",

--- a/frontend/src/hooks/useSSEHandlers.ts
+++ b/frontend/src/hooks/useSSEHandlers.ts
@@ -1,0 +1,240 @@
+/**
+ * useSSEHandlers — SSE event handlers for ThinkingView streaming.
+ * Manages node/edge mutations in response to SSE events from the thinking pipeline.
+ */
+import { useCallback } from "react";
+import type { Node as RFNode, Edge as RFEdge } from "@xyflow/react";
+import type {
+  ThinkingNode,
+  ThinkingSession,
+  SSENodeStart,
+  SSENodeText,
+  SSENodeComplete,
+  SSELayerComplete,
+  SSESessionComplete,
+  SSEEdgesPayload,
+} from "../types/thinking";
+import { nodeStyle, concentricPosition } from "../lib/thinking-graph-builder";
+import { createLogger } from "../lib/logger";
+
+const log = createLogger("sse-handlers");
+
+interface UseSSEHandlersArgs {
+  setNodes: React.Dispatch<React.SetStateAction<RFNode[]>>;
+  setEdges: React.Dispatch<React.SetStateAction<RFEdge[]>>;
+  setSession: React.Dispatch<React.SetStateAction<ThinkingSession | null>>;
+  setIsPending: React.Dispatch<React.SetStateAction<boolean>>;
+  layerNodeCounts: React.MutableRefObject<Map<number, number>>;
+  positionMap: React.MutableRefObject<Map<string, { x: number; y: number }>>;
+}
+
+export function useSSEHandlers({
+  setNodes,
+  setEdges,
+  setSession,
+  setIsPending,
+  layerNodeCounts,
+  positionMap,
+}: UseSSEHandlersArgs) {
+  const handleNodeStart = useCallback(
+    (data: SSENodeStart) => {
+      const { id, layer, type, parent_ids } = data;
+      const count = (layerNodeCounts.current.get(layer) ?? 0) + 1;
+      layerNodeCounts.current.set(layer, count);
+      const idx = count - 1;
+
+      setNodes((prev) => {
+        const updated = prev.map((n) => {
+          if (n.data.layer !== layer) return n;
+          const existingIdx = prev
+            .filter((p) => p.data.layer === layer)
+            .indexOf(n);
+          const pos = concentricPosition(layer, existingIdx, count);
+          positionMap.current.set(n.id, pos);
+          return { ...n, position: pos };
+        });
+
+        const pos = concentricPosition(layer, idx, count);
+        positionMap.current.set(id, pos);
+        const newNode: RFNode = {
+          id,
+          type: "streaming",
+          position: pos,
+          data: {
+            label: "",
+            type,
+            layer,
+            selected: true,
+            reasoning: "",
+            streaming: true,
+            parent_ids,
+          },
+          style: nodeStyle(type, true, layer),
+        };
+        return [...updated, newNode];
+      });
+
+      setSession((prev) => {
+        if (!prev) return prev;
+        const newThinkingNode: ThinkingNode = {
+          id,
+          layer,
+          type: type as ThinkingNode["type"],
+          content: "",
+          reasoning: "",
+          sources: [],
+          parents: parent_ids,
+          selected: true,
+          metadata: {},
+        };
+        return {
+          ...prev,
+          nodes: [...prev.nodes, newThinkingNode],
+          current_layer: Math.max(prev.current_layer, layer),
+        };
+      });
+    },
+    [setNodes, setSession, layerNodeCounts, positionMap],
+  );
+
+  const handleNodeText = useCallback(
+    (data: SSENodeText) => {
+      const { id, field, delta } = data;
+      setNodes((prev) =>
+        prev.map((n) => {
+          if (n.id !== id) return n;
+          if (field === "content") {
+            return {
+              ...n,
+              data: { ...n.data, label: (n.data.label ?? "") + delta },
+            };
+          }
+          return {
+            ...n,
+            data: { ...n.data, reasoning: (n.data.reasoning ?? "") + delta },
+          };
+        }),
+      );
+
+      setSession((prev) => {
+        if (!prev) return prev;
+        return {
+          ...prev,
+          nodes: prev.nodes.map((n) => {
+            if (n.id !== id) return n;
+            if (field === "content")
+              return { ...n, content: n.content + delta };
+            return { ...n, reasoning: n.reasoning + delta };
+          }),
+        };
+      });
+    },
+    [setNodes, setSession],
+  );
+
+  const handleNodeComplete = useCallback(
+    (data: SSENodeComplete) => {
+      const { id, confidence, metadata } = data;
+      setNodes((prev) =>
+        prev.map((n) => {
+          if (n.id !== id) return n;
+          return {
+            ...n,
+            data: { ...n.data, streaming: false, confidence },
+          };
+        }),
+      );
+
+      setSession((prev) => {
+        if (!prev) return prev;
+        return {
+          ...prev,
+          nodes: prev.nodes.map((n) =>
+            n.id !== id
+              ? n
+              : { ...n, metadata: { ...n.metadata, ...metadata, confidence } },
+          ),
+        };
+      });
+    },
+    [setNodes, setSession],
+  );
+
+  const handleEdges = useCallback(
+    (payload: SSEEdgesPayload) => {
+      const data = payload.edges;
+      const newEdges: RFEdge[] = data.map((e, i) => {
+        const isMatch = e.relationship === "matches";
+        const isConfirm =
+          e.relationship === "compounds" || e.relationship === "causes";
+        return {
+          id: `sse-e-${Date.now()}-${i}-${e.source}-${e.target}`,
+          source: e.source,
+          target: e.target,
+          label: e.relationship,
+          type: "smoothstep",
+          animated: true,
+          markerEnd: {
+            type: "arrowclosed" as const,
+            color: isMatch
+              ? "rgba(34, 197, 94, 0.6)"
+              : "rgba(255, 255, 255, 0.3)",
+            width: 15,
+            height: 15,
+          },
+          style: {
+            stroke: isMatch
+              ? "rgba(34, 197, 94, 0.4)"
+              : isConfirm
+                ? "rgba(255, 255, 255, 0.2)"
+                : "rgba(107, 115, 148, 0.3)",
+            strokeWidth: isMatch ? 2 : 1.5,
+          },
+          labelStyle: {
+            fill: isMatch ? "#86efac" : "#6b7394",
+            fontSize: 10,
+          },
+        };
+      });
+      setEdges((prev) => [...prev, ...newEdges]);
+
+      setSession((prev) => {
+        if (!prev) return prev;
+        return { ...prev, edges: [...prev.edges, ...data] };
+      });
+    },
+    [setEdges, setSession],
+  );
+
+  const handleLayerComplete = useCallback(
+    (data: SSELayerComplete) => {
+      setSession((prev) => {
+        if (!prev) return prev;
+        return { ...prev, current_layer: data.layer };
+      });
+      log.info("Layer", data.layer, "complete:", data.controller.summary);
+    },
+    [setSession],
+  );
+
+  const handleSessionComplete = useCallback(
+    (data: SSESessionComplete) => {
+      setSession((prev) => {
+        if (!prev) return prev;
+        return { ...prev, status: data.status as ThinkingSession["status"] };
+      });
+      setIsPending(false);
+      log.info("Session complete:", data.status);
+    },
+    [setSession, setIsPending],
+  );
+
+  return {
+    handleNodeStart,
+    handleNodeText,
+    handleNodeComplete,
+    handleEdges,
+    handleLayerComplete,
+    handleSessionComplete,
+  };
+}

--- a/frontend/src/hooks/useSSEHandlers.ts
+++ b/frontend/src/hooks/useSSEHandlers.ts
@@ -206,6 +206,68 @@ export function useSSEHandlers({
     [setEdges, setSession],
   );
 
+  const handleOpportunity = useCallback(
+    (data: Record<string, unknown>) => {
+      const opp = data as {
+        id: string;
+        layer: number;
+        type: string;
+        content: string;
+        reasoning: string;
+        confidence: number;
+        parents: string[];
+      };
+      const layer = opp.layer ?? 0;
+      const count = (layerNodeCounts.current.get(layer) ?? 0) + 1;
+      layerNodeCounts.current.set(layer, count);
+
+      const pos = concentricPosition(layer, count - 1, count);
+      positionMap.current.set(opp.id, pos);
+
+      setNodes((prev) => [
+        ...prev,
+        {
+          id: opp.id,
+          type: "streaming",
+          position: pos,
+          data: {
+            label: opp.content,
+            type: "opportunity",
+            layer,
+            selected: true,
+            reasoning: opp.reasoning,
+            confidence: opp.confidence,
+          },
+          style: nodeStyle("opportunity", true, layer),
+        },
+      ]);
+
+      setSession((prev) => {
+        if (!prev) return prev;
+        return {
+          ...prev,
+          nodes: [
+            ...prev.nodes,
+            {
+              id: opp.id,
+              layer,
+              type: "opportunity" as const,
+              content: opp.content,
+              reasoning: opp.reasoning ?? "",
+              sources: [],
+              parents: opp.parents ?? [],
+              selected: true,
+              metadata: data,
+            },
+          ],
+        };
+      });
+
+      log.info("Opportunity node:", opp.content);
+    },
+    [setNodes, setSession, layerNodeCounts, positionMap],
+  );
+
   const handleLayerComplete = useCallback(
     (data: SSELayerComplete) => {
       setSession((prev) => {
@@ -234,6 +296,7 @@ export function useSSEHandlers({
     handleNodeText,
     handleNodeComplete,
     handleEdges,
+    handleOpportunity,
     handleLayerComplete,
     handleSessionComplete,
   };

--- a/frontend/src/hooks/useSSESession.ts
+++ b/frontend/src/hooks/useSSESession.ts
@@ -14,6 +14,7 @@ interface SSECallbacks {
   onNodeText?: (data: SSENodeText) => void;
   onNodeComplete?: (data: SSENodeComplete) => void;
   onEdges?: (data: SSEEdgesPayload) => void;
+  onOpportunity?: (data: Record<string, unknown>) => void;
   onLayerComplete?: (data: SSELayerComplete) => void;
   onSessionComplete?: (data: SSESessionComplete) => void;
   onError?: (data: SSEError) => void;
@@ -57,6 +58,9 @@ export function useSSESession(
       });
       es.addEventListener("edges", (e: MessageEvent) => {
         cbRef.current?.onEdges?.(JSON.parse(e.data));
+      });
+      es.addEventListener("opportunity", (e: MessageEvent) => {
+        cbRef.current?.onOpportunity?.(JSON.parse(e.data));
       });
       es.addEventListener("layer_complete", (e: MessageEvent) => {
         cbRef.current?.onLayerComplete?.(JSON.parse(e.data));

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -135,25 +135,9 @@ body {
   background: rgba(255, 255, 255, 0.15);
 }
 
-/* React Flow node position animation — explode from center */
+/* React Flow node position animation — smooth transition */
 .react-flow__node {
-  transition: transform 0.8s cubic-bezier(0.34, 1.56, 0.64, 1) !important;
-}
-
-/* Soft float on inner node content (not the wrapper — React Flow owns that transform) */
-.react-flow__node > div {
-  animation: nodeFloat 4s ease-in-out infinite;
-  animation-delay: calc(var(--float-delay, 0) * 1s);
-}
-
-@keyframes nodeFloat {
-  0%,
-  100% {
-    margin-top: 0;
-  }
-  50% {
-    margin-top: -3px;
-  }
+  transition: transform 0.6s cubic-bezier(0.25, 1, 0.5, 1) !important;
 }
 
 /* Pool card floating animation */

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -378,7 +378,17 @@ body {
   border-radius: 8px;
   border: 1px solid transparent;
   transition: all 0.2s ease;
-  cursor: default;
+  cursor: pointer;
+}
+
+.opp-strip__item[data-pinned="true"] {
+  background: rgba(34, 197, 94, 0.1);
+  border-color: rgba(34, 197, 94, 0.3);
+}
+
+.opp-strip__pip[data-pinned="true"] {
+  box-shadow: 0 0 10px rgba(34, 197, 94, 0.8);
+  transform: scale(1.3);
 }
 
 .opp-strip__item:hover {

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -230,6 +230,189 @@ body {
   }
 }
 
+/* ─── Causal Chain (detail panel flowchart) ─── */
+
+.causal-chain {
+  border-top: 1px solid rgba(255, 255, 255, 0.06);
+  padding: 12px 16px;
+}
+
+.causal-chain__label {
+  font-size: 9px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  color: #6b7394;
+  margin-bottom: 10px;
+}
+
+.causal-chain__flow {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+.causal-chain__step {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  width: 100%;
+}
+
+.causal-chain__card {
+  width: 100%;
+  padding: 8px 10px;
+  border: 1px solid;
+  border-radius: 8px;
+  backdrop-filter: blur(8px);
+}
+
+.causal-chain__header {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  margin-bottom: 4px;
+}
+
+.causal-chain__dot {
+  width: 5px;
+  height: 5px;
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+
+.causal-chain__type {
+  font-size: 9px;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+
+.causal-chain__conf {
+  margin-left: auto;
+  font-size: 10px;
+  font-weight: 600;
+  color: #6b7394;
+}
+
+.causal-chain__text {
+  font-size: 11px;
+  line-height: 1.4;
+  color: #c8cad0;
+  overflow: hidden;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+}
+
+.causal-chain__arrow {
+  padding: 2px 0;
+  display: flex;
+  justify-content: center;
+}
+
+/* ─── Opportunity Strip (top hover panel) ─── */
+
+.opp-strip {
+  position: absolute;
+  top: 0;
+  left: 50%;
+  transform: translateX(-50%);
+  z-index: 25;
+  transition: all 0.25s ease;
+}
+
+.opp-strip__bar {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 14px;
+  background: rgba(15, 20, 35, 0.85);
+  backdrop-filter: blur(12px);
+  border: 1px solid rgba(34, 197, 94, 0.15);
+  border-top: none;
+  border-radius: 0 0 10px 10px;
+  cursor: default;
+}
+
+.opp-strip__label {
+  font-family: "DM Sans", system-ui, sans-serif;
+  font-size: 10px;
+  font-weight: 600;
+  color: #22c55e;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  white-space: nowrap;
+}
+
+.opp-strip__pips {
+  display: flex;
+  gap: 4px;
+}
+
+.opp-strip__pip {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: #22c55e;
+  box-shadow: 0 0 6px rgba(34, 197, 94, 0.4);
+}
+
+.opp-strip__list {
+  background: rgba(10, 14, 25, 0.95);
+  backdrop-filter: blur(16px);
+  border: 1px solid rgba(34, 197, 94, 0.12);
+  border-top: none;
+  border-radius: 0 0 12px 12px;
+  padding: 8px;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  max-height: 280px;
+  overflow-y: auto;
+  min-width: 320px;
+}
+
+.opp-strip__item {
+  padding: 8px 10px;
+  border-radius: 8px;
+  border: 1px solid transparent;
+  transition: all 0.2s ease;
+  cursor: default;
+}
+
+.opp-strip__item:hover {
+  background: rgba(34, 197, 94, 0.06);
+  border-color: rgba(34, 197, 94, 0.2);
+}
+
+.opp-strip__item-header {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  margin-bottom: 3px;
+}
+
+.opp-strip__ticker {
+  font-family: "DM Sans", system-ui, sans-serif;
+  font-size: 13px;
+  font-weight: 700;
+  color: #86efac;
+}
+
+.opp-strip__conv {
+  font-size: 14px;
+  font-weight: 800;
+  color: #22c55e;
+  letter-spacing: -0.02em;
+}
+
+.opp-strip__reasoning {
+  font-size: 11px;
+  line-height: 1.4;
+  color: #6b7394;
+}
+
 /* Pool card floating animation */
 @keyframes float {
   0%,

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -140,6 +140,96 @@ body {
   transition: transform 0.6s cubic-bezier(0.25, 1, 0.5, 1) !important;
 }
 
+/* ─── Nexis Node System ─── */
+
+.nexis-node {
+  font-family: "DM Sans", "Inter", system-ui, sans-serif;
+  pointer-events: auto;
+}
+
+/* News & Effect pill */
+.nexis-node__body {
+  display: flex;
+  align-items: flex-start;
+  gap: 8px;
+  padding: 10px 14px;
+  min-width: 100px;
+  max-width: 180px;
+}
+
+.nexis-node__dot {
+  flex-shrink: 0;
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  margin-top: 4px;
+  background: currentColor;
+  box-shadow: 0 0 6px currentColor;
+}
+
+.nexis-node__content {
+  flex: 1;
+  min-width: 0;
+}
+
+.nexis-node__text {
+  font-size: 13px;
+  font-weight: 550;
+  line-height: 1.35;
+  overflow: hidden;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+}
+
+.nexis-node__cursor {
+  display: inline-block;
+  width: 2px;
+  height: 14px;
+  margin-left: 2px;
+  background: currentColor;
+  opacity: 0.5;
+  animation: blink 1s step-end infinite;
+}
+
+.nexis-node__conf {
+  display: inline-block;
+  margin-top: 4px;
+  font-size: 10px;
+  font-weight: 600;
+  opacity: 0.5;
+  letter-spacing: 0.03em;
+}
+
+/* Opportunity node — centered, prominent */
+.nexis-node__opp {
+  padding: 12px 18px;
+  text-align: center;
+  min-width: 90px;
+  max-width: 160px;
+}
+
+.nexis-node__opp-label {
+  font-size: 14px;
+  font-weight: 700;
+  line-height: 1.3;
+  letter-spacing: -0.01em;
+}
+
+.nexis-node__opp-conf {
+  margin-top: 4px;
+  font-size: 20px;
+  font-weight: 800;
+  letter-spacing: -0.02em;
+  opacity: 0.9;
+}
+
+@keyframes blink {
+  50% {
+    opacity: 0;
+  }
+}
+
 /* Pool card floating animation */
 @keyframes float {
   0%,

--- a/frontend/src/lib/layout.ts
+++ b/frontend/src/lib/layout.ts
@@ -100,7 +100,7 @@ export function layoutGraph(
         },
         center.x,
         center.y,
-      ).strength(1.2),
+      ).strength(1.0),
     );
   }
 

--- a/frontend/src/lib/layout.ts
+++ b/frontend/src/lib/layout.ts
@@ -93,10 +93,14 @@ export function layoutGraph(
     simulation.force(
       "radial",
       forceRadial<ForceNode>(
-        (d) => (layerMap.get(d.id) ?? 0) * layerRadius,
+        (d) => {
+          const layer = layerMap.get(d.id) ?? 0;
+          // Layer 0 gets a small inner ring; other layers start at layerRadius
+          return layer === 0 ? 80 : layer * layerRadius;
+        },
         center.x,
         center.y,
-      ).strength(0.8),
+      ).strength(1.2),
     );
   }
 

--- a/frontend/src/lib/thinking-graph-builder.ts
+++ b/frontend/src/lib/thinking-graph-builder.ts
@@ -31,29 +31,30 @@ export function nodeStyle(
   const layerColor = LAYER_COLORS[Math.min(layer, LAYER_COLORS.length - 1)];
   const color = type === "opportunity" ? TYPE_COLORS.opportunity : layerColor;
   const isOpp = type === "opportunity";
+
+  if (isOpp) {
+    return {
+      background: "rgba(34, 197, 94, 0.08)",
+      backdropFilter: "blur(16px)",
+      color: "#86efac",
+      border: "1.5px solid rgba(34, 197, 94, 0.35)",
+      borderRadius: 14,
+      boxShadow:
+        "0 0 30px rgba(34, 197, 94, 0.15), 0 0 60px rgba(34, 197, 94, 0.05)",
+      transition: "all 0.3s ease",
+    };
+  }
+
   return {
-    background: isOpp
-      ? "rgba(34, 197, 94, 0.15)"
-      : selected
-        ? "rgba(15, 20, 35, 0.85)"
-        : "rgba(15, 20, 35, 0.4)",
+    background: selected ? "rgba(15, 20, 35, 0.9)" : "rgba(15, 20, 35, 0.5)",
     backdropFilter: "blur(12px)",
-    color: selected ? (isOpp ? "#86efac" : "#f0f0f5") : "#6b7394",
-    border: isOpp
-      ? "2px solid rgba(34, 197, 94, 0.4)"
-      : `1px solid ${selected ? "rgba(255,255,255,0.1)" : "rgba(255,255,255,0.04)"}`,
-    borderLeft: !isOpp ? `3px solid ${color}` : undefined,
-    borderRadius: isOpp ? 16 : 12,
-    padding: "8px 12px",
-    fontSize: 11,
-    fontWeight: isOpp ? 700 : 500,
-    minWidth: 120,
-    maxWidth: 180,
-    textAlign: isOpp ? ("center" as const) : undefined,
-    boxShadow: isOpp
-      ? "0 0 25px rgba(34, 197, 94, 0.2), 0 4px 20px rgba(0,0,0,0.4)"
-      : `0 4px 20px rgba(0,0,0,0.3), 0 0 15px ${color}10`,
-    transition: "background 0.3s, border-color 0.3s, color 0.3s",
+    color: selected ? color : "#6b7394",
+    border: `1px solid ${selected ? `${color}30` : "rgba(255,255,255,0.05)"}`,
+    borderRadius: 10,
+    boxShadow: selected
+      ? `0 0 20px ${color}12, 0 4px 16px rgba(0,0,0,0.3)`
+      : "0 2px 10px rgba(0,0,0,0.2)",
+    transition: "all 0.3s ease",
   };
 }
 
@@ -65,7 +66,7 @@ export function concentricPosition(
   layer: number,
   index: number,
   totalInLayer: number,
-  layerRadius: number = 400,
+  layerRadius: number = 300,
 ): { x: number; y: number } {
   if (layer === 0) {
     // News stays at center — small cluster
@@ -103,7 +104,7 @@ export function buildThinkingGraph(
     style: nodeStyle(n.type, n.selected, n.layer),
   }));
 
-  // Build React Flow edges
+  // Build React Flow edges — no labels to reduce clutter
   const rfEdges: RFEdge[] = edges.map((e, i) => {
     const isMatch = e.relationship === "matches";
     const isConfirm =
@@ -112,32 +113,26 @@ export function buildThinkingGraph(
       id: `e-${i}-${e.source}-${e.target}`,
       source: e.source,
       target: e.target,
-      label: e.relationship,
       type: "smoothstep",
-      animated: true,
+      animated: isMatch,
       markerEnd: {
         type: "arrowclosed" as const,
-        color: isMatch ? "rgba(34, 197, 94, 0.6)" : "rgba(255, 255, 255, 0.3)",
-        width: 15,
-        height: 15,
+        color: isMatch ? "rgba(34, 197, 94, 0.5)" : "rgba(255, 255, 255, 0.2)",
+        width: 12,
+        height: 12,
       },
       style: {
         stroke: isMatch
-          ? "rgba(34, 197, 94, 0.4)"
+          ? "rgba(34, 197, 94, 0.3)"
           : isConfirm
-            ? "rgba(255, 255, 255, 0.2)"
-            : "rgba(107, 115, 148, 0.3)",
-        strokeWidth: isMatch ? 2 : 1.5,
-      },
-      labelStyle: {
-        fill: isMatch ? "#86efac" : "#6b7394",
-        fontSize: 10,
+            ? "rgba(255, 255, 255, 0.12)"
+            : "rgba(107, 115, 148, 0.15)",
+        strokeWidth: isMatch ? 1.5 : 1,
       },
     };
   });
 
-  // Apply concentric ring layout — strong repulsion to prevent overlap
-  // Opportunity nodes go on outer ring (max_layer + 1) so they don't crowd the center
+  // Apply concentric ring layout
   const maxLayer = Math.max(...nodes.map((n) => n.layer ?? 0), 0);
   const layerMap = new Map(
     nodes.map((n) => [
@@ -145,16 +140,16 @@ export function buildThinkingGraph(
       n.type === "opportunity" ? maxLayer + 1 : (n.layer ?? 0),
     ]),
   );
-  // Scale layout params with node count — more nodes need more space
+  // Scale with node count — more nodes need more space
   const n = nodes.length;
-  const scale = Math.max(1, n / 15); // 1x at 15 nodes, 2x at 30, etc.
+  const scale = Math.max(1, n / 15);
   const layoutNodes = layoutGraph(rfNodes, rfEdges, {
-    chargeStrength: -800 * scale,
-    linkDistance: 200 * Math.sqrt(scale),
-    collideRadius: 160 * Math.sqrt(scale),
+    chargeStrength: -600 * scale,
+    linkDistance: 180 * Math.sqrt(scale),
+    collideRadius: 110 * Math.sqrt(scale),
     iterations: 200 + n * 2,
     layerMap,
-    layerRadius: 400,
+    layerRadius: 300,
     fixedPositions,
   });
 

--- a/frontend/src/lib/thinking-graph-builder.ts
+++ b/frontend/src/lib/thinking-graph-builder.ts
@@ -44,11 +44,11 @@ export function nodeStyle(
       : `1px solid ${selected ? "rgba(255,255,255,0.1)" : "rgba(255,255,255,0.04)"}`,
     borderLeft: !isOpp ? `3px solid ${color}` : undefined,
     borderRadius: isOpp ? 16 : 12,
-    padding: "10px 14px",
-    fontSize: 12,
+    padding: "8px 12px",
+    fontSize: 11,
     fontWeight: isOpp ? 700 : 500,
-    minWidth: 140,
-    maxWidth: 200,
+    minWidth: 120,
+    maxWidth: 180,
     textAlign: isOpp ? ("center" as const) : undefined,
     boxShadow: isOpp
       ? "0 0 25px rgba(34, 197, 94, 0.2), 0 4px 20px rgba(0,0,0,0.4)"
@@ -65,11 +65,12 @@ export function concentricPosition(
   layer: number,
   index: number,
   totalInLayer: number,
-  layerRadius: number = 180,
+  layerRadius: number = 350,
 ): { x: number; y: number } {
   if (layer === 0) {
+    // Scale layer-0 radius with node count so seeds never overlap
+    const r = totalInLayer > 1 ? Math.max(200, totalInLayer * 50) : 0;
     const angle = (index / Math.max(totalInLayer, 1)) * 2 * Math.PI;
-    const r = totalInLayer > 1 ? 60 : 0;
     return { x: Math.cos(angle) * r, y: Math.sin(angle) * r };
   }
   const r = layer * layerRadius;
@@ -146,14 +147,14 @@ export function buildThinkingGraph(
   );
   // Scale layout params with node count — more nodes need more space
   const n = nodes.length;
-  const scale = Math.max(1, n / 15); // 1x at 15 nodes, 2x at 30, etc.
+  const scale = Math.max(1, n / 10); // 1x at 10 nodes, 2x at 20, etc.
   const layoutNodes = layoutGraph(rfNodes, rfEdges, {
-    chargeStrength: -800 * scale,
-    linkDistance: 200 * Math.sqrt(scale),
-    collideRadius: 130 * Math.sqrt(scale),
-    iterations: 200 + n * 2,
+    chargeStrength: -1500 * scale,
+    linkDistance: 350 * Math.sqrt(scale),
+    collideRadius: 200 * Math.sqrt(scale),
+    iterations: 300 + n * 3,
     layerMap,
-    layerRadius: 250,
+    layerRadius: 400,
     fixedPositions,
   });
 

--- a/frontend/src/lib/thinking-graph-builder.ts
+++ b/frontend/src/lib/thinking-graph-builder.ts
@@ -65,10 +65,10 @@ export function concentricPosition(
   layer: number,
   index: number,
   totalInLayer: number,
-  layerRadius: number = 250,
+  layerRadius: number = 400,
 ): { x: number; y: number } {
   if (layer === 0) {
-    // Keep news at center — small cluster, d3 radial also targets radius 0
+    // News stays at center — small cluster
     const r = totalInLayer > 1 ? 80 : 0;
     const angle = (index / Math.max(totalInLayer, 1)) * 2 * Math.PI;
     return { x: Math.cos(angle) * r, y: Math.sin(angle) * r };
@@ -154,7 +154,7 @@ export function buildThinkingGraph(
     collideRadius: 160 * Math.sqrt(scale),
     iterations: 200 + n * 2,
     layerMap,
-    layerRadius: 250,
+    layerRadius: 400,
     fixedPositions,
   });
 

--- a/frontend/src/lib/thinking-graph-builder.ts
+++ b/frontend/src/lib/thinking-graph-builder.ts
@@ -65,11 +65,10 @@ export function concentricPosition(
   layer: number,
   index: number,
   totalInLayer: number,
-  layerRadius: number = 350,
+  layerRadius: number = 180,
 ): { x: number; y: number } {
   if (layer === 0) {
-    // Scale layer-0 radius with node count so seeds never overlap
-    const r = totalInLayer > 1 ? Math.max(200, totalInLayer * 50) : 0;
+    const r = totalInLayer > 1 ? 60 : 0;
     const angle = (index / Math.max(totalInLayer, 1)) * 2 * Math.PI;
     return { x: Math.cos(angle) * r, y: Math.sin(angle) * r };
   }
@@ -147,14 +146,14 @@ export function buildThinkingGraph(
   );
   // Scale layout params with node count — more nodes need more space
   const n = nodes.length;
-  const scale = Math.max(1, n / 10); // 1x at 10 nodes, 2x at 20, etc.
+  const scale = Math.max(1, n / 15); // 1x at 15 nodes, 2x at 30, etc.
   const layoutNodes = layoutGraph(rfNodes, rfEdges, {
-    chargeStrength: -1500 * scale,
-    linkDistance: 350 * Math.sqrt(scale),
-    collideRadius: 200 * Math.sqrt(scale),
-    iterations: 300 + n * 3,
+    chargeStrength: -800 * scale,
+    linkDistance: 200 * Math.sqrt(scale),
+    collideRadius: 160 * Math.sqrt(scale),
+    iterations: 200 + n * 2,
     layerMap,
-    layerRadius: 400,
+    layerRadius: 250,
     fixedPositions,
   });
 

--- a/frontend/src/lib/thinking-graph-builder.ts
+++ b/frontend/src/lib/thinking-graph-builder.ts
@@ -86,6 +86,7 @@ export function buildThinkingGraph(
   // Build React Flow nodes
   const rfNodes: RFNode[] = nodes.map((n) => ({
     id: n.id,
+    type: "streaming",
     position: { x: 0, y: 0 },
     data: {
       label: n.content,
@@ -93,6 +94,10 @@ export function buildThinkingGraph(
       layer: n.layer,
       selected: n.selected,
       reasoning: n.reasoning,
+      confidence:
+        (n.metadata?.confidence as number) ??
+        (n as unknown as Record<string, unknown>).confidence ??
+        undefined,
     },
     style: nodeStyle(n.type, n.selected, n.layer),
   }));
@@ -131,14 +136,21 @@ export function buildThinkingGraph(
   });
 
   // Apply concentric ring layout — strong repulsion to prevent overlap
-  const layerMap = new Map(nodes.map((n) => [n.id, n.layer]));
+  // Opportunity nodes go on outer ring (max_layer + 1) so they don't crowd the center
+  const maxLayer = Math.max(...nodes.map((n) => n.layer ?? 0), 0);
+  const layerMap = new Map(
+    nodes.map((n) => [
+      n.id,
+      n.type === "opportunity" ? maxLayer + 1 : (n.layer ?? 0),
+    ]),
+  );
   const layoutNodes = layoutGraph(rfNodes, rfEdges, {
-    chargeStrength: -600,
-    linkDistance: 150,
-    collideRadius: 100,
-    iterations: 150,
+    chargeStrength: -800,
+    linkDistance: 200,
+    collideRadius: 130,
+    iterations: 200,
     layerMap,
-    layerRadius: 180,
+    layerRadius: 250,
     fixedPositions,
   });
 

--- a/frontend/src/lib/thinking-graph-builder.ts
+++ b/frontend/src/lib/thinking-graph-builder.ts
@@ -144,11 +144,14 @@ export function buildThinkingGraph(
       n.type === "opportunity" ? maxLayer + 1 : (n.layer ?? 0),
     ]),
   );
+  // Scale layout params with node count — more nodes need more space
+  const n = nodes.length;
+  const scale = Math.max(1, n / 15); // 1x at 15 nodes, 2x at 30, etc.
   const layoutNodes = layoutGraph(rfNodes, rfEdges, {
-    chargeStrength: -800,
-    linkDistance: 200,
-    collideRadius: 130,
-    iterations: 200,
+    chargeStrength: -800 * scale,
+    linkDistance: 200 * Math.sqrt(scale),
+    collideRadius: 130 * Math.sqrt(scale),
+    iterations: 200 + n * 2,
     layerMap,
     layerRadius: 250,
     fixedPositions,

--- a/frontend/src/lib/thinking-graph-builder.ts
+++ b/frontend/src/lib/thinking-graph-builder.ts
@@ -65,10 +65,11 @@ export function concentricPosition(
   layer: number,
   index: number,
   totalInLayer: number,
-  layerRadius: number = 180,
+  layerRadius: number = 250,
 ): { x: number; y: number } {
   if (layer === 0) {
-    const r = totalInLayer > 1 ? 60 : 0;
+    // Keep news at center — small cluster, d3 radial also targets radius 0
+    const r = totalInLayer > 1 ? 80 : 0;
     const angle = (index / Math.max(totalInLayer, 1)) * 2 * Math.PI;
     return { x: Math.cos(angle) * r, y: Math.sin(angle) * r };
   }


### PR DESCRIPTION
## Summary
- **Cron pre-populate**: pools load from DB on startup + 2-hour periodic refresh, write-aside cache from cron→MongoDB→pools cache→Neo4j graph
- **Thinking graph UX overhaul**: compact signal nodes (13px/550-weight), concentric ring layout with 300px layer spacing, no-overlap collision detection
- **SSE edge rendering fix**: remap streaming node IDs to batch IDs so edges actually render in the graph
- **Opportunity SSE events**: wired `opportunity` event from backend to frontend — green glow nodes with conviction% now appear on outer ring
- **Causal chain flowchart**: click any node to see vertical mini-flowchart tracing news→effects→opportunity path
- **Opportunity strip**: top hover panel listing all opportunities with pin/unpin (same as graph click)
- **Layer color legend**: bottom-left indicator for News/Effects L1-L3/Opportunities

## Test Plan
- [x] 567 backend tests pass
- [x] Auto-run produces concentric ring graph with edges + opportunity nodes
- [x] Opportunity strip expands on hover, pin/unpin highlights causal path
- [x] Clicking node shows detail panel with causal chain flowchart
- [x] Pools load from DB cache, not live API on every request
- [x] Agent face hides when effect nodes arrive

🤖 Generated with [Claude Code](https://claude.com/claude-code)