### PR TITLE
refactor: migrate Neo4j to shared dev instance on :7690

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,73 @@
-.PHONY: dev down logs test health lint fmt build prod test-ci
+.PHONY: dev down logs test health lint fmt build prod test-ci \
+        neo4j neo4j-status neo4j-stop neo4j-wipe-nexis
 
-dev:
+# ─── Shared Neo4j (lives outside docker-compose) ────────────────────────────
+# This project shares one host-level Neo4j container across sibling local
+# projects to save RAM (~1.5GB per instance). Isolation is via Graphiti's
+# group_id="nexis" namespacing. See docs/shared-neo4j.md.
+NEO4J_CONTAINER := neo4j-shared
+NEO4J_VOLUME    := neo4j-shared-data
+NEO4J_PASSWORD  := shared-dev-password
+
+dev: neo4j
 	docker compose up -d
 
+# Ensure the shared Neo4j container is running and ready.
+# - creates the data volume if missing
+# - creates the container if missing (with APOC + memory settings)
+# - starts it if stopped
+# - waits until cypher-shell answers before returning
+neo4j:
+	@if ! docker volume inspect $(NEO4J_VOLUME) >/dev/null 2>&1; then \
+		echo "→ creating volume $(NEO4J_VOLUME)"; \
+		docker volume create $(NEO4J_VOLUME) >/dev/null; \
+	fi
+	@if ! docker ps -a --format '{{.Names}}' | grep -qx "$(NEO4J_CONTAINER)"; then \
+		echo "→ creating $(NEO4J_CONTAINER) on :7690 (host) → :7687 (container)"; \
+		docker run -d --name $(NEO4J_CONTAINER) --restart unless-stopped \
+			-p 7690:7687 -p 7475:7474 \
+			-v $(NEO4J_VOLUME):/data \
+			-e NEO4J_AUTH=neo4j/$(NEO4J_PASSWORD) \
+			-e NEO4J_PLUGINS='["apoc"]' \
+			-e NEO4J_server_memory_heap_initial__size=512m \
+			-e NEO4J_server_memory_heap_max__size=1G \
+			-e NEO4J_server_memory_pagecache_size=512m \
+			neo4j:5 >/dev/null; \
+	elif ! docker ps --format '{{.Names}}' | grep -qx "$(NEO4J_CONTAINER)"; then \
+		echo "→ starting existing $(NEO4J_CONTAINER)"; \
+		docker start $(NEO4J_CONTAINER) >/dev/null; \
+	else \
+		echo "→ $(NEO4J_CONTAINER) already running"; \
+	fi
+	@echo "→ waiting for Neo4j to accept queries..."
+	@for i in $$(seq 1 60); do \
+		if docker exec $(NEO4J_CONTAINER) cypher-shell -u neo4j -p $(NEO4J_PASSWORD) "RETURN 1" >/dev/null 2>&1; then \
+			echo "✓ Neo4j ready at bolt://localhost:7690 (browser: http://localhost:7475)"; \
+			exit 0; \
+		fi; \
+		sleep 1; \
+	done; \
+	echo "✗ Neo4j did not become ready in 60s"; exit 1
+
+neo4j-status:
+	@docker ps -a --filter "name=$(NEO4J_CONTAINER)" --format "table {{.Names}}\t{{.Status}}\t{{.Ports}}"
+
+# Does NOT stop the shared container by default — other projects may depend on it.
+neo4j-stop:
+	@echo "⚠  $(NEO4J_CONTAINER) is shared with other projects."
+	@echo "   This will stop it for everyone. Continue? (ctrl-C to abort)"
+	@read _
+	docker stop $(NEO4J_CONTAINER)
+
+# Wipe ONLY this project's data (group_id='nexis'), preserves sibling projects.
+neo4j-wipe-nexis:
+	docker exec $(NEO4J_CONTAINER) cypher-shell -u neo4j -p $(NEO4J_PASSWORD) \
+		"MATCH (n) WHERE n.group_id = 'nexis' DETACH DELETE n;"
+
+# `down` only stops the app stack; shared Neo4j is left running on purpose.
 down:
 	docker compose down
+	@echo "ℹ  $(NEO4J_CONTAINER) left running (shared resource). Use 'make neo4j-stop' to stop."
 
 logs:
 	docker compose logs -f

--- a/backend/.env.base
+++ b/backend/.env.base
@@ -1,9 +1,9 @@
 ENVIRONMENT=development
 MONGODB_URL=mongodb://localhost:27017/financial_agent_v2
 REDIS_URL=redis://localhost:6379/0
-NEO4J_URI=bolt://localhost:7687
+NEO4J_URI=bolt://localhost:7690
 NEO4J_USER=neo4j
-NEO4J_PASSWORD=nexis-dev-password
+NEO4J_PASSWORD=shared-dev-password
 SECRET_KEY=dev-secret-change-in-production
 LOG_LEVEL=DEBUG
 SILICONFLOW_API_KEY=

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -16,8 +16,10 @@ ENVIRONMENT=development
 MONGODB_URL=mongodb://mongodb:27017/financial_agent_v2
 REDIS_URL=redis://redis:6379/0
 
-# --- Neo4j ---
-NEO4J_URI=bolt://localhost:7687
+# --- Neo4j (shared dev instance on :7690 — see docs/shared-neo4j.md) ---
+# Host-run backend: localhost:7690
+# Docker-compose backend: host.docker.internal:7690
+NEO4J_URI=bolt://localhost:7690
 NEO4J_USER=neo4j
 
 # --- Logging ---

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,14 +12,16 @@ services:
         condition: service_healthy
       redis:
         condition: service_healthy
-      neo4j:
-        condition: service_healthy
+    # Neo4j runs as a shared dev instance (see docs/shared-neo4j.md).
+    # host.docker.internal lets the backend container reach the host-bound 7690 port.
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
     environment:
       MONGODB_URL: mongodb://mongodb:27017/financial_agent_v2
       REDIS_URL: redis://redis:6379/0
-      NEO4J_URI: bolt://neo4j:7687
+      NEO4J_URI: bolt://host.docker.internal:7690
       NEO4J_USER: neo4j
-      NEO4J_PASSWORD: ${NEO4J_PASSWORD:-nexis-dev-password}
+      NEO4J_PASSWORD: ${NEO4J_PASSWORD:-shared-dev-password}
       OPENAI_API_KEY: ${SILICONFLOW_API_KEY:-}
       OPENAI_BASE_URL: https://api.siliconflow.cn/v1
       ENVIRONMENT: development
@@ -65,28 +67,11 @@ services:
       timeout: 5s
       retries: 5
 
-  neo4j:
-    image: neo4j:5.26-community
-    ports:
-      - "7474:7474"
-      - "7687:7687"
-    volumes:
-      - neo4j_data:/data
-    environment:
-      NEO4J_AUTH: neo4j/${NEO4J_PASSWORD:-nexis-dev-password}
-      NEO4J_PLUGINS: '["apoc"]'
-      NEO4J_server_memory_heap_initial__size: 512m
-      NEO4J_server_memory_heap_max__size: 1G
-      NEO4J_server_memory_pagecache_size: 512m
-    healthcheck:
-      test: ["CMD-SHELL", "neo4j status || exit 1"]
-      interval: 10s
-      timeout: 10s
-      retries: 10
-      start_period: 30s
-    restart: unless-stopped
+# Neo4j is no longer a service in this stack — we use the shared dev instance
+# started outside docker-compose. See docs/shared-neo4j.md for setup.
+# Pre-migration this was: image neo4j:5.26-community on ports 7474/7687,
+# APOC plugin, 512m/1G heap, 512m pagecache, password nexis-dev-password.
 
 volumes:
   mongodb_data:
   redis_data:
-  neo4j_data:

--- a/docs/shared-neo4j.md
+++ b/docs/shared-neo4j.md
@@ -1,0 +1,76 @@
+# Shared Neo4j Dev Instance
+
+This project does **not** run its own Neo4j inside `docker-compose`. It connects to
+a single `neo4j-shared` container running on the host, which is also used by
+sibling local projects (e.g., `experiemnt_zep_rag`). Isolation between projects is
+enforced via Graphiti's `group_id` namespacing — this project uses `group_id="nexis"`.
+
+## Connection
+
+| Context | URI |
+|---|---|
+| Host-run backend (`.env.base`) | `bolt://localhost:7690` |
+| `docker-compose` backend | `bolt://host.docker.internal:7690` |
+| User | `neo4j` |
+| Password | `shared-dev-password` |
+| Browser UI | `http://localhost:7475` |
+
+`docker-compose.yml` injects `extra_hosts: host.docker.internal:host-gateway` so
+the backend container can reach the host's 7690 port on Linux as well as macOS.
+
+## Starting / Managing the Shared Instance
+
+One-time setup:
+
+```bash
+docker volume create neo4j-shared-data
+docker run -d --name neo4j-shared --restart unless-stopped \
+  -p 7690:7687 -p 7475:7474 \
+  -v neo4j-shared-data:/data \
+  -e NEO4J_AUTH=neo4j/shared-dev-password \
+  -e NEO4J_PLUGINS='["apoc"]' \
+  -e NEO4J_server_memory_heap_initial__size=512m \
+  -e NEO4J_server_memory_heap_max__size=1G \
+  -e NEO4J_server_memory_pagecache_size=512m \
+  neo4j:5
+```
+
+Ready check:
+
+```bash
+docker exec neo4j-shared cypher-shell -u neo4j -p shared-dev-password "RETURN 1"
+```
+
+## Inspect / Wipe Only This Project's Data
+
+Namespace is `group_id="nexis"`. To wipe just this project's data without affecting
+siblings:
+
+```cypher
+MATCH (n) WHERE n.group_id = 'nexis' DETACH DELETE n;
+```
+
+To count nodes per group (sanity check when multiple projects share the DB):
+
+```cypher
+MATCH (n) WITH n.group_id AS gid, count(*) AS c RETURN gid, c ORDER BY c DESC;
+```
+
+## Migration History
+
+- **Before:** this stack ran its own `neo4j:5.26-community` service inside
+  `docker-compose.yml` with volume `neo4j_data`, exposed on host port 7687,
+  password `nexis-dev-password`.
+- **Migration (2026-04-17):** data copied volume-to-volume
+  (`cron-prepopulate_neo4j_data` → `neo4j-shared-data`), container recreated on
+  port 7690 with APOC and matching memory settings, password rotated to
+  `shared-dev-password`. 265 Episodic + 228 Entity nodes preserved, all with
+  `group_id="nexis"`.
+- The old `cron-prepopulate_neo4j_data` volume is retained for now as a backup.
+
+## Rollback
+
+If the shared instance becomes problematic, revert by restoring the `neo4j`
+service block in `docker-compose.yml` (see git history) and pointing
+`NEO4J_URI` back to `bolt://neo4j:7687`. Data in the shared instance for
+`group_id="nexis"` can be copied back via the same volume-copy technique.

--- a/docs/shared-neo4j.md
+++ b/docs/shared-neo4j.md
@@ -20,7 +20,18 @@ the backend container can reach the host's 7690 port on Linux as well as macOS.
 
 ## Starting / Managing the Shared Instance
 
-One-time setup:
+**Preferred:** use the Makefile. It is idempotent — creates the volume,
+creates/starts the container, and waits until Neo4j answers queries.
+
+```bash
+make dev               # bootstraps Neo4j (if needed), then `docker compose up -d`
+make neo4j             # just ensure Neo4j is running (no compose stack)
+make neo4j-status      # show the container's state
+make neo4j-wipe-nexis  # wipe ONLY this project's data (group_id='nexis')
+make neo4j-stop        # stop shared container — prompts first, affects siblings
+```
+
+Under the hood, `make neo4j` runs this (useful if you prefer raw docker):
 
 ```bash
 docker volume create neo4j-shared-data
@@ -35,7 +46,7 @@ docker run -d --name neo4j-shared --restart unless-stopped \
   neo4j:5
 ```
 
-Ready check:
+Ready check (already built into `make neo4j`):
 
 ```bash
 docker exec neo4j-shared cypher-shell -u neo4j -p shared-dev-password "RETURN 1"


### PR DESCRIPTION
## Summary
- Remove the in-stack `neo4j` service from `docker-compose.yml`; backend now connects to the host-bound `neo4j-shared` container via `bolt://host.docker.internal:7690` (uses `extra_hosts: host.docker.internal:host-gateway` for Linux parity).
- Update `backend/.env.base` and `backend/.env.example` to point at `bolt://localhost:7690` with `shared-dev-password` for host-run backends.
- Add `docs/shared-neo4j.md` covering connection URIs per caller, start-up, `group_id` namespacing, per-project wipe/inspect queries, migration history, and rollback.

Project isolation is preserved via Graphiti `group_id="nexis"`; sibling projects use their own prefixes (e.g., `benchmark_*`).

## Data migration
Volume-copied `cron-prepopulate_neo4j_data` → `neo4j-shared-data`, rotated password from `nexis-dev-password` → `shared-dev-password` via `ALTER CURRENT USER`. **265 Episodic + 228 Entity nodes preserved**, all still under `group_id="nexis"`. The old volume is retained as a backup.

## Test plan
- [x] `docker compose config` parses; `neo4j` no longer in services list
- [x] Host Python client: `bolt://localhost:7690` + `shared-dev-password` returns `{'gid': 'nexis'}` via `MATCH (n) WHERE n.group_id IS NOT NULL RETURN DISTINCT n.group_id`
- [x] Containerized Python client: `bolt://host.docker.internal:7690` sees all 493 nexis nodes (265 + 228)
- [x] `apoc.version()` returns `5.26.24` from the shared instance
- [ ] Backend starts cleanly against the new URI and exercises `group_id="nexis"` queries end-to-end (not yet rerun after migration — recommend a quick `docker compose up` sanity check before merge)

## Rollback
Restore the `neo4j` service block in `docker-compose.yml` from git history and swap `NEO4J_URI` back to `bolt://neo4j:7687`. Data can be copied back to a fresh volume from `neo4j-shared-data` if needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)