### PR TITLE
chore: check in orphaned planning docs and rules

### DIFF
--- a/.claude/rules/cron-run-on-start-must-be-nonblocking.md
+++ b/.claude/rules/cron-run-on-start-must-be-nonblocking.md
@@ -1,0 +1,17 @@
+# Cron run_on_start Must Be Non-Blocking
+
+## The Trap
+Using `await self._run_job(name)` for `run_on_start=True` jobs in `CronManager.start_all()`. Pipeline handlers (news fetch, yfinance) take 10-60s. This blocks the FastAPI lifespan startup — the server accepts zero HTTP connections until all startup jobs complete. Health checks timeout, load balancers mark the instance as dead.
+
+## The Solution
+Fire `run_on_start` jobs as background tasks, not awaited:
+```python
+if config.run_on_start:
+    asyncio.create_task(self._run_job(name))  # non-blocking
+```
+The overlap prevention in `_run_job` still works — `state.running = True` prevents the first periodic loop iteration from double-running.
+
+## Context
+- **When this applies:** Any startup initialization that runs potentially slow async handlers
+- **Related files:** `backend/src/cron/manager.py`
+- **Discovered:** 2026-04-13, live E2E — backend accepted no connections for 60s while yfinance fetched

--- a/backend/tests/quality-gates.md
+++ b/backend/tests/quality-gates.md
@@ -1,0 +1,318 @@
+# Quality Gates: Qdrant → Graphiti/Neo4j Migration
+
+## Codebase Baseline Summary
+
+| Metric | Current Value |
+|--------|--------------|
+| Total test functions | 552 |
+| Test categories | root (240), benchmark (179), rag (67), api (28), pipelines (12), core (7) |
+| RAG-specific tests | 67 (protocols, search, persistence, decay, config, e2e pipeline, Qdrant integration, search_nodes tool) |
+| Benchmark scenarios | 2 (Iran Escalation, Fed Rate Decision) |
+| Benchmark grade | B (≥0.70) |
+| RAG search baseline | NDCG@20=0.611, Recall@20=1.0, MRR=0.572 (FakeEmbedding hash-based) |
+| Protocols | VectorStore, EmbeddingProvider, SparseEncoder, NodeRepository (all @runtime_checkable) |
+| Fakes | FakeVectorStore, FakeEmbedding, FakeSparseEncoder, FakeNodeRepo |
+| Persistence model | Dual-write: MongoDB sync (source of truth) + Qdrant async (search index) |
+| Agent tools | SearchNodesTool (RAG search), FetchNewsTool (live news) |
+
+---
+
+## Gate 1: Search Quality
+
+### 1.1 Core Retrieval Metrics (relative to Qdrant baseline)
+
+| Metric | Qdrant Baseline | Minimum Target | Stretch Target |
+|--------|----------------|----------------|----------------|
+| NDCG@20 | 0.611 | **≥ 0.55** (-10%) | ≥ 0.65 (+6%) |
+| Recall@20 | 1.0 | **≥ 0.90** | ≥ 0.95 |
+| MRR | 0.572 | **≥ 0.50** (-12%) | ≥ 0.60 (+5%) |
+
+**Rationale:** A small regression is acceptable because Graphiti's value lies in relationship-aware retrieval, not raw vector similarity. The graph adds a new search dimension (traversal) that these metrics don't capture. However, flat retrieval must not degrade catastrophically.
+
+**Pass/Fail:** ALL three minimum targets must pass simultaneously. Missing any one is a FAIL.
+
+### 1.2 Graph-Specific Metrics (NEW — no baseline)
+
+| Metric | Minimum Target | How to Measure |
+|--------|----------------|----------------|
+| Entity resolution accuracy | **≥ 0.85** | Golden set of 20 entities with known aliases (e.g., "Fed" = "Federal Reserve" = "FOMC"). Measure: correct_merges / (correct_merges + false_splits + false_merges) |
+| Path discovery correctness | **≥ 0.80** | 10 causal chains from scenarios with known 2-hop paths. Measure: correctly_discovered_paths / total_expected_paths |
+| Temporal filtering accuracy | **≥ 0.95** | 10 queries with valid_at/invalid_at constraints. Measure: results_within_time_window / total_results |
+| Edge type correctness | **≥ 0.90** | 15 known relationships. Measure: correct_edge_type / total_edges_created |
+
+**Pass/Fail:** Each metric independently. Entity resolution and temporal filtering are HARD gates (must pass). Path discovery and edge type are SOFT gates (failure triggers review, not block).
+
+### 1.3 Golden Set Extension
+
+The existing golden set (`backend/tests/benchmark/rag/golden_set.py`) has 10 SEED_NODES and 6 GOLDEN_QUERIES. For graph testing, extend with:
+
+- **10 additional nodes** with explicit relationships (causal chains, entity references)
+- **4 graph-specific queries** testing traversal:
+  1. "What effects does Fed rate decision cause?" (1-hop traversal)
+  2. "What opportunities arise from oil supply disruption?" (2-hop: news → effect → opportunity)
+  3. "Find all entities related to NVIDIA" (entity fan-out)
+  4. "What changed between March 20 and March 25?" (temporal window)
+
+---
+
+## Gate 2: Performance
+
+### 2.1 Async Write Latency
+
+| Operation | Max Added Latency | Measurement Point |
+|-----------|-------------------|-------------------|
+| persist_node (user-facing) | **≤ 50ms p95** added vs current | Time from `persist_node()` call to MongoDB write completion (graph write is async, same pattern as current Qdrant async) |
+| Background graph write | **≤ 2000ms p95** | Time for `_background_index()` equivalent to complete graph entity+edge creation |
+| persist_batch (5 nodes) | **≤ 300ms p95** | End-to-end for 5-node batch with semaphore(5) |
+
+**Rationale:** The current dual-write pattern (MongoDB sync + Qdrant async) means user-facing latency is MongoDB-bound. Graph writes replace Qdrant async writes. The user must not notice the switch.
+
+**Pass/Fail:** User-facing latency is a HARD gate. Background write latency is SOFT (can be tuned post-launch).
+
+### 2.2 Search Latency
+
+| Operation | Target p95 | Measurement |
+|-----------|-----------|-------------|
+| Graph search (simple query) | **≤ 500ms** | Single semantic search equivalent to current `NodeSearchService.search()` |
+| Graph search (with traversal) | **≤ 1500ms** | Query + 2-hop traversal + result assembly |
+| Graph search (with temporal filter) | **≤ 800ms** | Search with valid_at/invalid_at constraints |
+
+**Pass/Fail:** Simple query is HARD. Traversal and temporal are SOFT.
+
+### 2.3 Resource Consumption
+
+| Resource | Target | Measurement |
+|----------|--------|-------------|
+| Neo4j Docker memory | **≤ 1GB** idle, **≤ 2GB** under load | `docker stats` during benchmark run |
+| Neo4j Docker CPU | **≤ 30%** idle (single core) | `docker stats` during 60s idle period |
+| Startup time (graph init) | **≤ 10s** | Time from `init_rag_services()` start to completion (includes Neo4j connection, schema setup) |
+| Total Docker memory (all services) | **≤ 4GB** | MongoDB + Redis + Neo4j + Backend combined |
+
+**Pass/Fail:** All SOFT gates — document actual values, flag if exceeded.
+
+---
+
+## Gate 3: Regression
+
+### 3.1 Existing Test Suite
+
+| Category | Count | Requirement |
+|----------|-------|-------------|
+| Root tests | 240 | **ALL must pass** (none touch Qdrant directly) |
+| Benchmark tests | 179 | **ALL must pass** (uses FakeVectorStore, not Qdrant) |
+| RAG tests (non-Qdrant) | 54 | **ALL must pass** (protocols, search, persistence, decay, config, e2e pipeline, search_nodes tool) |
+| RAG Qdrant integration | 13 | **Replace with Neo4j integration tests** (1:1 mapping) |
+| API tests | 28 | **ALL must pass** |
+| Pipeline tests | 12 | **ALL must pass** |
+| Core tests | 7 | **ALL must pass** |
+
+**Net test count:** 552 - 13 (Qdrant integration removed) + ≥15 (Neo4j integration added) + ≥12 (graph-specific new tests) = **≥ 566 tests**
+
+**Pass/Fail:** HARD gate. Zero regressions in non-Qdrant tests. Qdrant integration tests must be replaced 1:1.
+
+### 3.2 Benchmark Grade Maintenance
+
+| Scenario | Current Grade | Minimum Post-Migration |
+|----------|-------------|----------------------|
+| Iran Escalation | B (≥0.70) | **B (≥0.70)** |
+| Fed Rate Decision | B (≥0.70) | **B (≥0.70)** |
+
+The benchmark scoring weights are:
+- checkpoint_hit_rate: 25%, match_accuracy: 20%, reasoning_correctness: 20%, reasoning_completeness: 15%, match_quality: 10%, depth_appropriateness: 10%
+
+The graph migration should not affect Pass 1 scores (checkpoint scanning, match scanning — these are trace-based, not search-based). Pass 2 (LLM judge) is also trace-based. The only indirect impact is if graph-powered search_nodes tool returns different results that change agent reasoning quality.
+
+**Pass/Fail:** HARD gate. Run both scenarios post-migration. Grade must be ≥ B.
+
+### 3.3 API Contract Stability
+
+| Endpoint | Contract |
+|----------|---------|
+| All frontend-facing endpoints | **Response shape unchanged** — frontend must work without modification |
+| SearchNodesTool interface | Input schema (`SearchNodesInput`) unchanged — agents use this tool |
+| FetchNewsTool interface | No changes (not RAG-dependent) |
+
+**Pass/Fail:** HARD gate. Verified by existing API tests + manual E2E.
+
+---
+
+## Gate 4: Code Quality
+
+### 4.1 Protocol-Based DI
+
+| Requirement | Details |
+|-------------|---------|
+| New `GraphStore` protocol | Must be defined in `backend/src/rag/protocols.py` alongside existing protocols |
+| `FakeGraphStore` for tests | In-memory implementation in `backend/src/rag/fakes.py`, no Neo4j required |
+| Existing protocols preserved | `VectorStore` protocol can be removed ONLY after all references are migrated |
+| DI wiring | `dependencies.py` must wire `GraphStore` the same way it wires `VectorStore` today — lazy imports, init function |
+
+**Pass/Fail:** HARD gate. `isinstance(FakeGraphStore(), GraphStore)` must return True (runtime_checkable).
+
+### 4.2 Test Coverage
+
+| Component | Minimum Coverage |
+|-----------|-----------------|
+| GraphStore protocol + implementation | **≥ 90%** line coverage |
+| Graph search service | **≥ 85%** line coverage |
+| Graph persistence (dual-write) | **≥ 85%** line coverage |
+| Graph tools (new) | **≥ 80%** line coverage |
+| FakeGraphStore | **100%** (it's test infrastructure) |
+
+**Pass/Fail:** SOFT gate — document actual coverage, flag if below threshold.
+
+### 4.3 Architectural Rules
+
+| Rule | Verification |
+|------|-------------|
+| No hardcoded Neo4j URLs | Grep for `bolt://` or `neo4j://` outside config files |
+| Clean MongoDB/Neo4j separation | MongoDB = metadata/state, Neo4j = relationships/search. No mixed queries. |
+| No workarounds | No `# TODO`, `# HACK`, `# WORKAROUND` in new code |
+| Lazy imports maintained | Neo4j/Graphiti imports inside `init_*()` functions, not module-level |
+| No mock suppression | Tests use FakeGraphStore, not `@mock.patch` on Neo4j client |
+
+**Pass/Fail:** HARD gate (all rules). Verified by grep + code review agent.
+
+---
+
+## Gate 5: Integration Test Scenarios
+
+### 5.1 News → Graph → Search Roundtrip
+
+**Setup:** Persist 3 news nodes with known content.
+**Action:** Search for one by semantic query.
+**Verify:**
+- Node found with correct content, metadata, and score
+- Graph entity created for key entities in news (e.g., "Federal Reserve")
+- Relationships between entities stored as edges
+- `session_id` exclusion filter works
+
+### 5.2 Thinking → Effect → Graph Reuse
+
+**Setup:** Run a thinking layer that produces effect nodes. Persist them.
+**Action:** In a NEW session, search for effects from the prior session.
+**Verify:**
+- Cross-session search returns prior effects
+- Decay scoring applied correctly (newer effects score higher)
+- Graph traversal can follow causal chain (news → effect)
+
+### 5.3 Temporal Supersession
+
+**Setup:** Persist two versions of the same entity analysis (e.g., "NVIDIA outlook" from March 20 and March 25).
+**Action:** Search with `date_from="2026-03-24"`.
+**Verify:**
+- Only the March 25 version returned
+- Older version's `invalid_at` set correctly (if using Graphiti temporal model)
+- Graph edges reflect the temporal relationship
+
+### 5.4 Cross-Session Knowledge Reuse
+
+**Setup:** Session A persists: news → effect_1 → opportunity_1. Session B starts.
+**Action:** Session B agent uses `search_nodes` tool.
+**Verify:**
+- Session B finds Session A's analysis
+- Graph provides richer context than flat search (shows causal chain)
+- Session B's own nodes excluded from results
+
+### 5.5 Graph Tool Chaining Patterns (NEW tools)
+
+These test the tiered graph tools mentioned in Task #6:
+
+| Tool Pattern | Test |
+|-------------|------|
+| **Drill-down** | Search "Fed rate impact" → get entity → traverse to connected effects |
+| **Connection discovery** | Given two entities ("NVIDIA", "China tariffs"), find connecting paths |
+| **Temporal comparison** | Compare entity state at two time points |
+| **Neighborhood exploration** | Given one effect node, find all related entities within 2 hops |
+
+Each pattern: verify correct results, verify no false connections, verify latency within Gate 2 targets.
+
+### 5.6 Reconciliation & Pruning
+
+**Setup:** Simulate a failed graph write (MongoDB succeeds, graph write fails).
+**Action:** Run `reconcile()`.
+**Verify:**
+- Unindexed node is re-indexed to graph
+- `indexed` flag updated in MongoDB
+- No duplicate entities/edges created
+
+**Setup:** Persist nodes with `created_at` > 90 days ago.
+**Action:** Run `prune()`.
+**Verify:**
+- Nodes removed from both MongoDB and graph store
+- Associated edges cleaned up (no orphan edges)
+
+---
+
+## Gate 6: Acceptance Criteria (Binary Pass/Fail)
+
+### HARD Gates (ALL must pass — migration is blocked if any fails)
+
+| # | Gate | Pass Condition |
+|---|------|---------------|
+| H1 | NDCG@20 ≥ 0.55 | `test_search_quality.py::test_ndcg_at_20` passes |
+| H2 | Recall@20 ≥ 0.90 | `test_search_quality.py::test_recall_at_20` passes |
+| H3 | MRR ≥ 0.50 | `test_search_quality.py::test_mrr` passes |
+| H4 | Entity resolution ≥ 0.85 | New `test_entity_resolution` passes |
+| H5 | Temporal filtering ≥ 0.95 | New `test_temporal_filtering` passes |
+| H6 | User-facing write latency ≤ 50ms p95 | New `test_write_latency` passes |
+| H7 | Simple search latency ≤ 500ms p95 | New `test_search_latency` passes |
+| H8 | Non-Qdrant tests pass (539) | `pytest -m "not integration"` — 0 failures |
+| H9 | Qdrant integration replaced 1:1 | ≥ 13 Neo4j integration tests pass |
+| H10 | Benchmark grade ≥ B (both scenarios) | `test_benchmark.py` — both scenarios grade ≥ B |
+| H11 | API contract unchanged | All API tests pass, no response shape changes |
+| H12 | GraphStore protocol with FakeGraphStore | `isinstance(FakeGraphStore(), GraphStore)` is True |
+| H13 | No architectural violations | Grep verification passes (no hardcoded URLs, no mixed queries, lazy imports) |
+
+### SOFT Gates (failure triggers review, documented with justification)
+
+| # | Gate | Pass Condition |
+|---|------|---------------|
+| S1 | Path discovery ≥ 0.80 | New test — review if below |
+| S2 | Edge type correctness ≥ 0.90 | New test — review if below |
+| S3 | Background write ≤ 2s p95 | Benchmark — document actual |
+| S4 | Traversal search ≤ 1.5s p95 | Benchmark — document actual |
+| S5 | Neo4j memory ≤ 2GB | docker stats — document actual |
+| S6 | Graph code coverage ≥ 85% | pytest-cov — document actual |
+| S7 | Net test count ≥ 566 | pytest --collect-only count |
+
+### Definition of "Done"
+
+The migration is **DONE** when:
+1. All 13 HARD gates pass with evidence (test output, benchmark reports)
+2. All SOFT gates are evaluated with documented values
+3. SOFT gate failures have written justification and remediation plan
+4. PR created with summary referencing this quality gates document
+5. Code review agent confirms architectural compliance
+
+---
+
+## Qdrant-Specific Test Inventory (to be replaced)
+
+These 13 tests in `backend/tests/rag/test_qdrant_integration.py` must be replaced with Neo4j equivalents:
+
+1. `test_ensure_collection_creates_collection` → `test_ensure_graph_schema`
+2. `test_ensure_collection_idempotent` → `test_ensure_graph_schema_idempotent`
+3. `test_upsert_and_retrieve` → `test_add_episode_and_search`
+4. `test_upsert_multiple_points` → `test_add_multiple_episodes`
+5. `test_write_then_search_immediate` → `test_write_then_search_immediate`
+6. `test_filter_by_node_type` → `test_filter_by_entity_type`
+7. `test_filter_by_min_confidence` → `test_filter_by_min_confidence`
+8. `test_filter_by_market` → `test_filter_by_market`
+9. `test_exclude_session_id` → `test_exclude_session_id`
+10. `test_combined_filters` → `test_combined_filters`
+11. `test_delete_removes_point` → `test_delete_removes_entity`
+12. `test_delete_empty_ids_is_noop` → `test_delete_empty_ids_is_noop`
+13. `test_rrf_fusion_returns_scored_results` → `test_graph_search_returns_scored_results`
+
+---
+
+## Key Risks & Mitigations
+
+| Risk | Impact | Mitigation |
+|------|--------|-----------|
+| Graphiti entity resolution is too aggressive (merges distinct entities) | False relationships, wrong search results | Tune entity resolution thresholds; golden set test catches this at Gate 1.2 |
+| Neo4j cold start is slow | Startup time exceeds 10s gate | Warmup query in init; document actual timing |
+| Graph traversal latency spikes under load | Agent tool becomes unusable | Limit traversal depth to 2 hops; cache hot paths |
+| SiliconFlow embeddings + Graphiti compatibility | Integration failures | Task #1 validates this specifically |
+| Dual-write to MongoDB + Neo4j doubles failure surface | Data inconsistency | Same reconciliation pattern as current Qdrant dual-write |

--- a/docs/superpowers/plans/2026-03-24-macro-news-pipeline.md
+++ b/docs/superpowers/plans/2026-03-24-macro-news-pipeline.md
@@ -1,0 +1,56 @@
+# Macro News Pipeline Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Broaden the news pool to include macro/geopolitical news by adding multi-source fetch (Perigon `/stories` + NewsAPI), fixing scoring to incentivize macro news, removing market partition on news, and giving the Thinker agent a `fetch_news` tool for directed search.
+
+**Architecture:** Three fetch modes (cron stories, cron broad, agent on-demand) feed a single global `news_entities` collection. Scoring uses scope + cluster factors instead of ticker relevance. A 40% tiered quota guarantees macro news representation. The agent can actively pull news mid-reasoning via a new tool.
+
+**Tech Stack:** Python, FastAPI, Motor (MongoDB async), httpx, CrewAI, Perigon API, NewsAPI
+
+**Spec:** `docs/superpowers/specs/2026-03-24-macro-news-pipeline-design.md`
+
+---
+
+## File Structure
+
+| File | Action | Responsibility |
+|------|--------|---------------|
+| `backend/src/models/news_entity.py` | Modify | Add `scope`, `origin`, `story_cluster_size`; remove `market` |
+| `backend/src/models/pool_common.py` | Modify | Make `FetchStrategy.fetch()` accept optional market |
+| `backend/src/pipelines/base.py` | Modify | Make `market` optional in `PoolPipeline` |
+| `backend/src/pipelines/news/score.py` | Modify | New formula: scope_factor + cluster_factor |
+| `backend/src/pipelines/news/process.py` | Modify | Remove `market` from `_gen_id` hash |
+| `backend/src/pipelines/news/fetch.py` | Rewrite | `PerigonStoriesFetch`, `PerigonAllFetch`, `NewsAPIHeadlinesFetch`, `CompositeFetch` |
+| `backend/src/pipelines/news/quota.py` | Create | Tiered quota enforcement |
+| `backend/src/services/newsapi.py` | Create | NewsAPI client with caching + keyword-based classification |
+| `backend/src/services/perigon.py` | Modify | Add `fetch_perigon_stories()`, broaden categories |
+| `backend/src/agents/tools/__init__.py` | Create | Package init |
+| `backend/src/agents/tools/fetch_news.py` | Create | Agent tool for directed news search |
+| `backend/src/agents/thinking_crew.py` | Modify | Register `FetchNewsTool` in Thinker agent |
+| `backend/src/database/repositories/news_entity_repo.py` | Modify | Support `market=None` queries |
+| `backend/src/api/pools.py` | Modify | Global news pool, market only for values |
+| `backend/src/api/thinking.py` | Modify | Global news pool loading + tiered quota |
+| `backend/src/cron/scheduler.py` | Modify | Single global news pipeline |
+| `backend/src/core/config.py` | Modify | Add new config fields |
+
+---
+
+## Tasks
+
+| # | Task | Files | Detail |
+|---|------|-------|--------|
+| 1 | Data Model + Config Changes | `news_entity.py`, `config.py` | [[tasks-1-3]] |
+| 2 | Scoring Redesign | `score.py`, `test_news_pipeline.py` | [[tasks-1-3]] |
+| 3 | Pipeline Infrastructure (market-optional) | `pool_common.py`, `base.py`, `process.py`, `news_entity_repo.py` | [[tasks-1-3]] |
+| 4 | NewsAPI Client | `newsapi.py` (new) | [[tasks-4-6]] |
+| 5 | Perigon Stories Fetch | `perigon.py` | [[tasks-4-6]] |
+| 6 | Composite Fetch + Pipeline Wiring | `fetch.py`, `scheduler.py` | [[tasks-4-6]] |
+| 7 | Agent `fetch_news` Tool | `tools/fetch_news.py` (new) | [[tasks-7-10]] |
+| 8 | Thinker Agent Integration | `thinking_crew.py` | [[tasks-7-10]] |
+| 9 | API Layer — Global Pool + Tiered Quota | `pools.py`, `thinking.py`, `quota.py` (new) | [[tasks-7-10]] |
+| 10 | Integration Test + Full Verification | integration test | [[tasks-7-10]] |
+
+**Dependency order:** Tasks 1-3 (foundation) → Tasks 4-6 (fetch sources) → Tasks 7-10 (integration)
+
+**Parallelism:** Tasks 4 and 5 are independent. Tasks 7 and 9 are independent.

--- a/docs/superpowers/plans/2026-03-26-sse-streaming-thinking.md
+++ b/docs/superpowers/plans/2026-03-26-sse-streaming-thinking.md
@@ -1,0 +1,1978 @@
+# SSE Streaming for Thinking Pipeline — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace 2-second polling with SSE streaming + LLM token-level streaming, so thinking nodes appear on the graph word-by-word as the LLM generates them.
+
+**Architecture:** Direct LiteLLM streaming for the thinker agent (bypass CrewAI), incremental JSON parsing to extract nodes mid-stream, asyncio.Queue per session for zero-poll event delivery, deterministic concentric ring layout with CSS entrance animations on the frontend.
+
+**Tech Stack:** LiteLLM (streaming), json-repair (incremental parsing), FastAPI StreamingResponse (SSE), React Flow (graph), EventSource (browser SSE client)
+
+**Spec:** `docs/superpowers/specs/2026-03-26-sse-streaming-thinking-design.md`
+
+---
+
+## File Structure
+
+### Backend (new files)
+
+| File | Responsibility |
+|------|---------------|
+| `backend/src/services/session_events.py` | Session registry (queue + task + cleanup), SSE event dataclasses, health check |
+| `backend/src/services/stream_parser.py` | Incremental JSON parser — consumes LLM token chunks, emits node objects and field deltas |
+
+### Backend (modified files)
+
+| File | Change |
+|------|--------|
+| `backend/src/agents/llm_config.py` | Add `get_litellm_params()` dict for direct LiteLLM calls |
+| `backend/src/agents/thinking_crew.py` | Extract thinker prompt builder into `build_thinker_prompt()` (shared between CrewAI and streaming path) |
+| `backend/src/services/thinking_service.py` | Add `run_layer_streaming()` — async, pushes events to queue |
+| `backend/src/api/thinking_auto.py` | Replace polling-SSE with queue-based SSE; integrate session registry; reconnection replay; pipeline loop uses `run_layer_streaming()` |
+| `backend/src/main.py` | Start periodic health check background task on startup |
+| `backend/pyproject.toml` | Add `json-repair` and move `litellm` to runtime dependencies |
+
+### Frontend (new files)
+
+| File | Responsibility |
+|------|---------------|
+| `frontend/src/hooks/useSSESession.ts` | EventSource lifecycle, reconnection, fallback to polling |
+| `frontend/src/hooks/useAnimationQueue.ts` | Stagger node entrance timing, minimum gap enforcement |
+| `frontend/src/components/StreamingNode.tsx` | Custom React Flow node with text streaming + entrance animation |
+
+### Frontend (modified files)
+
+| File | Change |
+|------|--------|
+| `frontend/src/types/thinking.ts` | Update SSE event types to match new protocol |
+| `frontend/src/lib/thinking-graph-builder.ts` | Add `concentricPosition()` for deterministic layout |
+| `frontend/src/components/ThinkingView.tsx` | Replace polling with `useSSESession`; use animation queue; register `StreamingNode` |
+
+### Test files
+
+| File | Coverage |
+|------|----------|
+| `backend/tests/test_stream_parser.py` | Incremental JSON parsing |
+| `backend/tests/test_session_events.py` | Queue lifecycle, overflow, cleanup |
+| `backend/tests/test_streaming_layer.py` | Streaming layer runner |
+| `backend/tests/test_sse_endpoint.py` | SSE event format, reconnection replay |
+| `frontend/src/lib/__tests__/concentric-layout.test.ts` | Deterministic position calculation |
+| `frontend/src/hooks/__tests__/useSSESession.test.ts` | EventSource mock, events, reconnection |
+| `frontend/src/hooks/__tests__/useAnimationQueue.test.ts` | Stagger timing, minimum gap, drain |
+
+---
+
+## Task 1: Session Event Registry
+
+**Files:**
+- Create: `backend/src/services/session_events.py`
+- Test: `backend/tests/test_session_events.py`
+
+- [ ] **Step 1: Write failing tests for session registry**
+
+```python
+# backend/tests/test_session_events.py
+import asyncio
+import pytest
+from src.services.session_events import (
+    SessionRegistry,
+    SessionEntry,
+    SSEEvent,
+    MAX_QUEUE_SIZE,
+    WARN_QUEUE_SIZE,
+)
+
+
+class TestSessionRegistry:
+    @pytest.mark.asyncio
+    async def test_create_and_get(self):
+        reg = SessionRegistry()
+        task = asyncio.ensure_future(asyncio.sleep(100))
+        entry = reg.create("sess1", task)
+        assert isinstance(entry, SessionEntry)
+        assert reg.get("sess1") is entry
+        task.cancel()
+
+    def test_get_missing_returns_none(self):
+        reg = SessionRegistry()
+        assert reg.get("nope") is None
+
+    @pytest.mark.asyncio
+    async def test_remove(self):
+        reg = SessionRegistry()
+        task = asyncio.ensure_future(asyncio.sleep(100))
+        reg.create("sess1", task)
+        reg.remove("sess1")
+        assert reg.get("sess1") is None
+
+    @pytest.mark.asyncio
+    async def test_active_count(self):
+        reg = SessionRegistry()
+        t1 = asyncio.ensure_future(asyncio.sleep(100))
+        t2 = asyncio.ensure_future(asyncio.sleep(100))
+        reg.create("a", t1)
+        reg.create("b", t2)
+        assert reg.active_count == 2
+        t1.cancel()
+        t2.cancel()
+
+
+class TestSSEEvent:
+    def test_serialize(self):
+        evt = SSEEvent(event="node_start", data={"id": "abc"}, id="layer:1:node:0")
+        text = evt.serialize()
+        assert "event: node_start\n" in text
+        assert 'data: {"id": "abc"}\n' in text
+        assert "id: layer:1:node:0\n" in text
+
+    def test_serialize_no_id(self):
+        evt = SSEEvent(event="error", data={"msg": "fail"})
+        text = evt.serialize()
+        assert "id:" not in text
+
+
+@pytest.mark.asyncio
+async def test_queue_put_and_get():
+    reg = SessionRegistry()
+    task = asyncio.current_task()
+    entry = reg.create("sess1", task)
+    evt = SSEEvent(event="test", data={"x": 1})
+    await entry.queue.put(evt)
+    got = await asyncio.wait_for(entry.queue.get(), timeout=1.0)
+    assert got.event == "test"
+```
+
+- [ ] **Step 2: Run tests — verify they fail**
+
+```bash
+cd /path/to/worktree && docker compose run --rm --no-deps backend python -m pytest tests/test_session_events.py -v
+```
+
+Expected: `ModuleNotFoundError: No module named 'src.services.session_events'`
+
+- [ ] **Step 3: Implement session_events.py**
+
+```python
+# backend/src/services/session_events.py
+"""Session event registry — queue + task per active auto-run session."""
+
+import asyncio
+import json
+import time
+from dataclasses import dataclass, field
+from typing import Any, Optional
+
+from src.core.logger import get_logger
+
+log = get_logger("session_events")
+
+MAX_QUEUE_SIZE = 500
+WARN_QUEUE_SIZE = 100
+
+
+@dataclass
+class SSEEvent:
+    """A single SSE event to push to the client."""
+    event: str
+    data: Any
+    id: Optional[str] = None
+
+    def serialize(self) -> str:
+        parts = [f"event: {self.event}"]
+        if self.id is not None:
+            parts.append(f"id: {self.id}")
+        payload = json.dumps(self.data, ensure_ascii=False) if not isinstance(self.data, str) else self.data
+        parts.append(f"data: {payload}")
+        return "\n".join(parts) + "\n\n"
+
+
+@dataclass
+class SessionEntry:
+    """One active auto-run session."""
+    queue: asyncio.Queue = field(default_factory=asyncio.Queue)
+    task: Optional[asyncio.Task] = None
+    created_at: float = field(default_factory=time.time)
+
+
+class SessionRegistry:
+    """In-memory registry of active SSE sessions."""
+
+    def __init__(self):
+        self._sessions: dict[str, SessionEntry] = {}
+
+    def create(self, session_id: str, task: asyncio.Task) -> SessionEntry:
+        entry = SessionEntry(task=task)
+        self._sessions[session_id] = entry
+        log.info("Session %s registered", session_id)
+        return entry
+
+    def get(self, session_id: str) -> Optional[SessionEntry]:
+        return self._sessions.get(session_id)
+
+    def remove(self, session_id: str) -> None:
+        entry = self._sessions.pop(session_id, None)
+        if entry and entry.task and not entry.task.done():
+            entry.task.cancel()
+        if entry:
+            log.info("Session %s removed", session_id)
+
+    @property
+    def active_count(self) -> int:
+        return len(self._sessions)
+
+    async def health_check(self) -> None:
+        for sid, entry in list(self._sessions.items()):
+            qsize = entry.queue.qsize()
+            if qsize > MAX_QUEUE_SIZE:
+                log.error("Session %s queue overflow (%d) — cancelling", sid, qsize)
+                self.remove(sid)
+            elif qsize > WARN_QUEUE_SIZE:
+                log.warning("Session %s queue backpressure: %d items", sid, qsize)
+        if self._sessions:
+            total = sum(e.queue.qsize() for e in self._sessions.values())
+            log.info("Active SSE sessions: %d, total queued: %d", len(self._sessions), total)
+
+
+# Module-level singleton
+registry = SessionRegistry()
+```
+
+- [ ] **Step 4: Run tests — verify they pass**
+
+```bash
+cd /path/to/worktree && docker compose run --rm --no-deps backend python -m pytest tests/test_session_events.py -v
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/src/services/session_events.py backend/tests/test_session_events.py
+git commit -m "feat(sse): add session event registry with queue + task lifecycle"
+```
+
+---
+
+## Task 2: Incremental JSON Stream Parser
+
+**Files:**
+- Create: `backend/src/services/stream_parser.py`
+- Test: `backend/tests/test_stream_parser.py`
+- Modify: `backend/pyproject.toml` (add `json-repair`)
+
+- [ ] **Step 1: Add json-repair and litellm to runtime dependencies**
+
+In `backend/pyproject.toml`, add `"json-repair>=0.25"` and `"litellm>=1.50"` to `dependencies` list (after `httpx`). LiteLLM is currently dev-only but the streaming path calls `litellm.acompletion` at runtime. Also remove `litellm` from `[project.optional-dependencies] dev` to avoid duplication.
+
+- [ ] **Step 2: Write failing tests**
+
+```python
+# backend/tests/test_stream_parser.py
+import pytest
+from src.services.stream_parser import IncrementalEffectsParser
+
+
+class TestIncrementalEffectsParser:
+    def test_single_complete_effect(self):
+        """Full JSON in one chunk → one complete node."""
+        parser = IncrementalEffectsParser()
+        chunk = '{"effects": [{"content": "Fed pause", "reasoning": "dovish", "confidence": 80, "parent_ids": ["s1"], "sector": "macro", "fetched_news_ids": [], "information_gaps": []}]}'
+        events = parser.feed(chunk)
+        # Should have node_start, node_text(s), node_complete
+        starts = [e for e in events if e["type"] == "node_start"]
+        completes = [e for e in events if e["type"] == "node_complete"]
+        assert len(starts) == 1
+        assert len(completes) == 1
+        assert completes[0]["data"]["confidence"] == 80
+
+    def test_streamed_chunks(self):
+        """JSON arrives in small chunks — nodes emitted when complete."""
+        parser = IncrementalEffectsParser()
+        chunks = [
+            '{"effects": [{"content": "Rate',
+            ' cut impact", "reasoning": "Fed',
+            ' signals easing", "confidence": 75,',
+            ' "parent_ids": ["s1"], "sector":',
+            ' "macro", "fetched_news_ids": [],',
+            ' "information_gaps": []}]}',
+        ]
+        all_events = []
+        for c in chunks:
+            all_events.extend(parser.feed(c))
+        completes = [e for e in all_events if e["type"] == "node_complete"]
+        assert len(completes) == 1
+
+    def test_multiple_effects(self):
+        """Two effects → two complete nodes."""
+        parser = IncrementalEffectsParser()
+        chunk = '{"effects": [{"content": "A", "reasoning": "r1", "confidence": 70, "parent_ids": ["s1"], "sector": "tech", "fetched_news_ids": [], "information_gaps": []}, {"content": "B", "reasoning": "r2", "confidence": 60, "parent_ids": ["s2"], "sector": "energy", "fetched_news_ids": [], "information_gaps": []}]}'
+        events = parser.feed(chunk)
+        completes = [e for e in events if e["type"] == "node_complete"]
+        assert len(completes) == 2
+
+    def test_markdown_fence_stripped(self):
+        """LLM wraps JSON in ```json ... ``` — parser handles it."""
+        parser = IncrementalEffectsParser()
+        chunk = '```json\n{"effects": [{"content": "X", "reasoning": "Y", "confidence": 50, "parent_ids": ["s1"], "sector": "fin", "fetched_news_ids": [], "information_gaps": []}]}\n```'
+        events = parser.feed(chunk)
+        completes = [e for e in events if e["type"] == "node_complete"]
+        assert len(completes) == 1
+
+    def test_text_deltas_emitted(self):
+        """Content field changes emit node_text events."""
+        parser = IncrementalEffectsParser()
+        chunks = [
+            '{"effects": [{"content": "Fed ',
+            'rate pause signals dovish ',
+            'pivot", "reasoning": "The hold',
+            ' despite pressure", "confidence": 78,',
+            ' "parent_ids": ["s1"], "sector": "macro",',
+            ' "fetched_news_ids": [], "information_gaps": []}]}',
+        ]
+        all_events = []
+        for c in chunks:
+            all_events.extend(parser.feed(c))
+        text_events = [e for e in all_events if e["type"] == "node_text"]
+        assert len(text_events) > 0
+        # Concatenated deltas should contain the full content
+        content_deltas = [e["data"]["delta"] for e in text_events if e["data"].get("field") == "content"]
+        assert "Fed " in "".join(content_deltas) or "rate" in "".join(content_deltas)
+
+    def test_empty_effects(self):
+        """Empty effects array → no events."""
+        parser = IncrementalEffectsParser()
+        events = parser.feed('{"effects": []}')
+        assert len([e for e in events if e["type"] == "node_complete"]) == 0
+
+    def test_malformed_prose_input(self):
+        """LLM returns prose instead of JSON → no crash, no events."""
+        parser = IncrementalEffectsParser()
+        events = parser.feed("I think the main effects would be inflation and trade disruption.")
+        assert len([e for e in events if e["type"] == "node_complete"]) == 0
+
+    def test_partial_json_then_complete(self):
+        """Truly broken partial JSON followed by valid completion."""
+        parser = IncrementalEffectsParser()
+        events1 = parser.feed('{"effects": [{"content": "partial')
+        # No complete nodes yet
+        assert len([e for e in events1 if e["type"] == "node_complete"]) == 0
+        events2 = parser.feed('", "reasoning": "r", "confidence": 60, "parent_ids": ["s1"], "sector": "x", "fetched_news_ids": [], "information_gaps": []}]}')
+        assert len([e for e in events2 if e["type"] == "node_complete"]) == 1
+```
+
+- [ ] **Step 3: Run tests — verify they fail**
+
+```bash
+cd /path/to/worktree && docker compose run --rm --no-deps backend python -m pytest tests/test_stream_parser.py -v
+```
+
+Expected: `ModuleNotFoundError: No module named 'src.services.stream_parser'`
+
+- [ ] **Step 4: Implement stream_parser.py**
+
+The parser tracks bracket depth within the `effects` array. When a top-level object in the array closes (`}` at depth 1), it extracts that object. Between closures, it emits `node_text` events as content/reasoning fields grow.
+
+```python
+# backend/src/services/stream_parser.py
+"""Incremental JSON parser for LLM-streamed thinker output.
+
+Consumes token chunks, emits events as node objects become complete.
+Handles markdown fences and partial JSON gracefully.
+"""
+
+import re
+from typing import Any
+from json_repair import repair_json
+
+from src.core.logger import get_logger
+
+log = get_logger("stream_parser")
+
+# Regex to strip ```json ... ``` fences
+_FENCE_RE = re.compile(r"^```(?:json)?\s*\n?", re.MULTILINE)
+_FENCE_END_RE = re.compile(r"\n?```\s*$", re.MULTILINE)
+
+
+def _strip_fences(text: str) -> str:
+    text = _FENCE_RE.sub("", text)
+    text = _FENCE_END_RE.sub("", text)
+    return text
+
+
+class IncrementalEffectsParser:
+    """Feed LLM chunks, get back structured events.
+
+    Events emitted:
+    - {"type": "node_start", "data": {"index": int}}
+    - {"type": "node_text", "data": {"index": int, "field": str, "delta": str}}
+    - {"type": "node_complete", "data": {"index": int, ...full effect dict}}
+    """
+
+    def __init__(self):
+        self._buffer = ""
+        self._completed_count = 0
+        self._last_content_len: dict[int, dict[str, int]] = {}  # index -> {field: len}
+
+    def feed(self, chunk: str) -> list[dict[str, Any]]:
+        """Feed a chunk of LLM output. Returns list of events."""
+        self._buffer += chunk
+        clean = _strip_fences(self._buffer)
+        events: list[dict[str, Any]] = []
+
+        # Try to extract complete effect objects using bracket tracking
+        effects = self._extract_effects(clean)
+        if effects is None:
+            # Can't parse yet — try emitting text deltas from partial parse
+            partial_events = self._emit_partial_deltas(clean)
+            events.extend(partial_events)
+            return events
+
+        # Emit events for newly completed effects
+        for i, effect in enumerate(effects):
+            if i < self._completed_count:
+                continue
+            # node_start
+            events.append({"type": "node_start", "data": {"index": i}})
+            # node_text for content
+            content = effect.get("content", "")
+            if content:
+                events.append({
+                    "type": "node_text",
+                    "data": {"index": i, "field": "content", "delta": content},
+                })
+            # node_text for reasoning
+            reasoning = effect.get("reasoning", "")
+            if reasoning:
+                events.append({
+                    "type": "node_text",
+                    "data": {"index": i, "field": "reasoning", "delta": reasoning},
+                })
+            # node_complete
+            events.append({"type": "node_complete", "data": {"index": i, **effect}})
+            self._completed_count = i + 1
+
+        return events
+
+    def _extract_effects(self, text: str) -> list[dict] | None:
+        """Try to parse complete effects from the buffer."""
+        try:
+            repaired = repair_json(text, return_objects=True)
+            if isinstance(repaired, dict) and "effects" in repaired:
+                effects = repaired["effects"]
+                if isinstance(effects, list):
+                    # Only return effects that look complete (have content + confidence)
+                    complete = [
+                        e for e in effects
+                        if isinstance(e, dict) and "content" in e and "confidence" in e
+                    ]
+                    if len(complete) > self._completed_count:
+                        return complete
+        except Exception:
+            pass
+        return None
+
+    def _emit_partial_deltas(self, text: str) -> list[dict[str, Any]]:
+        """Try to extract partial text deltas from incomplete JSON."""
+        events: list[dict[str, Any]] = []
+        try:
+            repaired = repair_json(text, return_objects=True)
+            if isinstance(repaired, dict) and "effects" in repaired:
+                effects = repaired.get("effects", [])
+                if not isinstance(effects, list):
+                    return events
+                for i, effect in enumerate(effects):
+                    if not isinstance(effect, dict):
+                        continue
+                    if i < self._completed_count:
+                        continue
+                    # Track field lengths and emit deltas
+                    if i not in self._last_content_len:
+                        self._last_content_len[i] = {}
+                        events.append({"type": "node_start", "data": {"index": i}})
+                    for field_name in ("content", "reasoning"):
+                        val = effect.get(field_name, "")
+                        if not val:
+                            continue
+                        prev_len = self._last_content_len[i].get(field_name, 0)
+                        if len(val) > prev_len:
+                            delta = val[prev_len:]
+                            events.append({
+                                "type": "node_text",
+                                "data": {"index": i, "field": field_name, "delta": delta},
+                            })
+                            self._last_content_len[i][field_name] = len(val)
+        except Exception:
+            pass
+        return events
+```
+
+- [ ] **Step 5: Run tests — verify they pass**
+
+```bash
+cd /path/to/worktree && docker compose run --rm --no-deps backend python -m pytest tests/test_stream_parser.py -v
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add backend/src/services/stream_parser.py backend/tests/test_stream_parser.py backend/pyproject.toml
+git commit -m "feat(sse): add incremental JSON parser for LLM-streamed thinker output"
+```
+
+---
+
+## Task 3: LiteLLM Streaming Config + Thinker Prompt Extraction
+
+**Files:**
+- Modify: `backend/src/agents/llm_config.py` (add `get_litellm_params()`)
+- Modify: `backend/src/agents/thinking_crew.py` (extract `build_thinker_prompt()`)
+- Test: `backend/tests/test_agents.py` (add test for new functions)
+
+- [ ] **Step 1: Write failing tests**
+
+Add to `backend/tests/test_agents.py`:
+
+```python
+class TestLiteLLMParams:
+    def test_returns_dict_with_required_keys(self, monkeypatch):
+        monkeypatch.setattr(
+            "src.agents.llm_config.settings",
+            type("S", (), {"siliconflow_api_key": "test-key"})(),
+        )
+        from src.agents.llm_config import get_litellm_params
+        params = get_litellm_params()
+        assert "model" in params
+        assert "api_key" in params
+        assert params["api_key"] == "test-key"
+        assert "api_base" in params
+
+
+class TestBuildThinkerPrompt:
+    def test_returns_string_with_parent_context(self):
+        from src.agents.thinking_crew import build_thinker_prompt
+        parents = [{"id": "s1", "content": "Fed pause", "layer": 0, "type": "news", "selected": True}]
+        news = [{"id": "n1", "title": "Rate news", "summary": "Summary"}]
+        prompt = build_thinker_prompt(
+            parent_nodes=parents, chain_summary="", news_pool=news, layer=1
+        )
+        assert "Fed pause" in prompt
+        assert "Rate news" in prompt
+        assert "Return ONLY valid JSON" in prompt
+```
+
+- [ ] **Step 2: Run tests — verify they fail**
+
+```bash
+cd /path/to/worktree && docker compose run --rm --no-deps backend python -m pytest tests/test_agents.py::TestLiteLLMParams -v
+cd /path/to/worktree && docker compose run --rm --no-deps backend python -m pytest tests/test_agents.py::TestBuildThinkerPrompt -v
+```
+
+- [ ] **Step 3: Add `get_litellm_params()` to llm_config.py**
+
+Add after `get_small_llm()` (after line 44):
+
+```python
+def get_litellm_params() -> dict:
+    """Return params dict for direct litellm.acompletion() calls."""
+    return {
+        "model": MAIN_MODEL,
+        "api_key": _get_api_key(),
+        "api_base": SILICONFLOW_BASE_URL,
+        "temperature": 0.3,
+    }
+```
+
+- [ ] **Step 4: Extract `build_thinker_prompt()` from thinking_crew.py**
+
+Extract the prompt-building logic from `run_thinker()` (lines 70-107 of `thinking_crew.py`) into a standalone function. The existing `run_thinker()` should call this new function. Add before `run_thinker()`:
+
+```python
+def build_thinker_prompt(
+    parent_nodes: list[dict],
+    chain_summary: str,
+    news_pool: list[dict],
+    layer: int,
+) -> str:
+    """Build the thinker agent prompt. Shared between CrewAI and direct LiteLLM paths.
+
+    NOTE: Import `prepare_parent_nodes` from `src.agents.thinking_helpers` (public name),
+    not the `_prepare_parent_nodes` private alias in this file.
+    """
+    parents_json = json.dumps(
+        prepare_parent_nodes(parent_nodes, current_layer=layer),
+        ensure_ascii=False,
+    )
+    pool_json = json.dumps(
+        [
+            {
+                "id": n.get("id", ""),
+                "title": n.get("title", n.get("summary", "")),
+                "summary": n.get("summary", ""),
+            }
+            for n in news_pool[:20]
+        ],
+        ensure_ascii=False,
+    )
+    chain_ctx = f"Chain summary so far:\n{chain_summary}\n\n" if chain_summary else ""
+    return (
+        f"{chain_ctx}"
+        f"Analyze these financial events and identify their next-order "
+        f"market effects.\n\n"
+        f"Parent nodes (layers 0-{layer - 1}):\n{parents_json}\n\n"
+        f"Available news pool:\n{pool_json}\n\n"
+        f"For each effect:\n"
+        f"1. Content — what happens\n"
+        f"2. Reasoning — the causal chain from parent(s)\n"
+        f"3. Confidence (0-100) — naturally lower for deeper chains\n"
+        f"4. Parent IDs — which parent(s) cause it\n"
+        f"5. Sector — affected sector\n"
+        f"6. Fetched news IDs — any news from pool you reference\n"
+        f"7. Information gaps — what you wish you knew\n\n"
+        f"Return JSON:\n"
+        f'{{"effects": [{{"content": str, "reasoning": str, '
+        f'"confidence": int, "parent_ids": [str], "sector": str, '
+        f'"fetched_news_ids": [str], "information_gaps": [str]}}]}}\n\n'
+        f"Return ONLY valid JSON."
+    )
+```
+
+Then update `run_thinker()` to call `build_thinker_prompt()` instead of inline prompt building. Replace lines 70-107 with:
+
+```python
+        description = build_thinker_prompt(
+            parent_nodes=parent_nodes,
+            chain_summary=chain_summary,
+            news_pool=news_pool,
+            layer=layer,
+        )
+        prompt_chars = len(description)
+```
+
+- [ ] **Step 5: Run ALL agent tests — verify they pass**
+
+```bash
+cd /path/to/worktree && docker compose run --rm --no-deps backend python -m pytest tests/test_agents.py -v
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add backend/src/agents/llm_config.py backend/src/agents/thinking_crew.py backend/tests/test_agents.py
+git commit -m "refactor(sse): extract thinker prompt builder + add litellm params helper"
+```
+
+---
+
+## Task 4: Streaming Layer Runner
+
+**Files:**
+- Modify: `backend/src/services/thinking_service.py` (add `run_layer_streaming()`)
+- Depends on: Task 1 (session_events), Task 2 (stream_parser), Task 3 (llm_config + prompt)
+
+- [ ] **Step 1: Write failing tests**
+
+```python
+# backend/tests/test_streaming_layer.py
+import asyncio
+import pytest
+from unittest.mock import AsyncMock, patch, MagicMock
+from src.services.session_events import SessionRegistry, SSEEvent
+from src.services.thinking_service import run_layer_streaming
+
+
+def _mock_stream_chunks():
+    """Simulate LiteLLM streaming response."""
+    chunks_text = [
+        '{"effects": [{"content": "Fed ',
+        'rate impact", "reasoning": "The',
+        ' pause signals easing", "confidence": 75,',
+        ' "parent_ids": ["s1"], "sector": "macro",',
+        ' "fetched_news_ids": [], "information_gaps": []}]}',
+    ]
+    for text in chunks_text:
+        chunk = MagicMock()
+        chunk.choices = [MagicMock()]
+        chunk.choices[0].delta.content = text
+        yield chunk
+
+
+@pytest.mark.asyncio
+async def test_run_layer_streaming_pushes_events():
+    """Streaming layer pushes node events to the queue."""
+    reg = SessionRegistry()
+    dummy_task = asyncio.current_task()
+    entry = reg.create("test-sess", dummy_task)
+
+    parents = [{"id": "s1", "content": "News", "layer": 0, "type": "news", "selected": True}]
+    news = [{"id": "n1", "title": "Test", "summary": "Sum"}]
+    value = [{"ticker": "AAPL", "sector": "tech", "discount_pct": 20}]
+
+    async def mock_acompletion(**kwargs):
+        """Return an async generator of chunks."""
+        async def gen():
+            for c in _mock_stream_chunks():
+                yield c
+        return gen()
+
+    with patch("src.services.thinking_service.litellm_acompletion", side_effect=mock_acompletion):
+        # Use AsyncMock — _call_with_retry is async, so side_effect values must be awaitable
+        mock_retry = AsyncMock()
+        mock_retry.side_effect = [
+            ([], [], 0),  # matcher returns empty
+            ({"continue": False, "reasoning": "stop", "summary": ""}, 0),  # controller stops
+        ]
+        with patch("src.services.thinking_service._call_with_retry", mock_retry):
+            await run_layer_streaming(
+                session_id="test-sess",
+                chain_summary="",
+                parent_nodes=parents,
+                news_pool=news,
+                value_pool=value,
+                layer=1,
+                max_depth=3,
+                registry=reg,
+            )
+
+    # Drain queue and check events
+    events = []
+    while not entry.queue.empty():
+        events.append(await entry.queue.get())
+    event_types = [e.event for e in events]
+    assert "node_start" in event_types
+    assert "node_complete" in event_types
+    assert "edges" in event_types
+    assert "layer_complete" in event_types
+```
+
+- [ ] **Step 2: Run test — verify it fails**
+
+```bash
+cd /path/to/worktree && docker compose run --rm --no-deps backend python -m pytest tests/test_streaming_layer.py -v
+```
+
+- [ ] **Step 3: Implement `run_layer_streaming()` in thinking_service.py**
+
+Add after `run_layer()` (after line 159):
+
+```python
+# Import at top of file (add these):
+# from src.services.session_events import SessionRegistry, SSEEvent
+# from src.services.stream_parser import IncrementalEffectsParser
+# from src.agents.llm_config import get_litellm_params
+# from src.agents.thinking_crew import build_thinker_prompt, _build_thinker_output, run_matcher, run_controller
+
+async def run_layer_streaming(
+    session_id: str,
+    chain_summary: str,
+    parent_nodes: list[dict],
+    news_pool: list[dict],
+    value_pool: list[dict],
+    layer: int,
+    max_depth: int,
+    registry: "SessionRegistry",
+    confidence_threshold: float = 35,
+) -> LayerResult:
+    """Run one pipeline layer with LLM streaming for the thinker.
+
+    Pushes SSEEvents to the session queue as nodes are generated.
+    Matcher and controller run batch (non-streaming).
+    """
+    entry = registry.get(session_id)
+    if not entry:
+        log.error("No session entry for %s — cannot stream", session_id)
+        return _empty_layer_result("Session not registered for streaming")
+
+    queue = entry.queue
+
+    # --- Thinker (streaming) ---
+    thinker_tokens = 0
+    effect_nodes = []
+    fetch_nodes = []
+    effect_edges = []
+    fetch_edges = []
+
+    try:
+        from src.agents.thinking_crew import build_thinker_prompt, _build_thinker_output
+        from src.agents.skills.base import build_system_prompt_with_skills
+        from src.agents.thinking_helpers import THINKER_SKILLS
+        from src.agents.llm_config import get_litellm_params
+
+        prompt = build_thinker_prompt(
+            parent_nodes=parent_nodes,
+            chain_summary=chain_summary,
+            news_pool=news_pool,
+            layer=layer,
+        )
+        system_prompt = build_system_prompt_with_skills(allowed_skills=THINKER_SKILLS)
+        params = get_litellm_params()
+
+        # Stream LLM response
+        parser = IncrementalEffectsParser()
+        full_text = ""
+        node_index_to_id: dict[int, str] = {}
+
+        response = await litellm_acompletion(
+            messages=[
+                {"role": "system", "content": system_prompt},
+                {"role": "user", "content": prompt},
+            ],
+            stream=True,
+            **params,
+        )
+
+        async for chunk in response:
+            delta = chunk.choices[0].delta.content or ""
+            if not delta:
+                continue
+            full_text += delta
+
+            events = parser.feed(delta)
+            for evt in events:
+                if evt["type"] == "node_start":
+                    idx = evt["data"]["index"]
+                    node_id = f"stream-{uuid4().hex[:8]}"
+                    node_index_to_id[idx] = node_id
+                    await queue.put(SSEEvent(
+                        event="node_start",
+                        data={"id": node_id, "layer": layer, "type": "effect", "parent_ids": [p["id"] for p in parent_nodes[:3]]},
+                        id=f"layer:{layer}:node:{idx}",
+                    ))
+                elif evt["type"] == "node_text":
+                    idx = evt["data"]["index"]
+                    nid = node_index_to_id.get(idx, "")
+                    await queue.put(SSEEvent(
+                        event="node_text",
+                        data={"id": nid, "field": evt["data"]["field"], "delta": evt["data"]["delta"]},
+                        id=f"layer:{layer}:node:{idx}:text",
+                    ))
+                elif evt["type"] == "node_complete":
+                    idx = evt["data"]["index"]
+                    nid = node_index_to_id.get(idx, "")
+                    await queue.put(SSEEvent(
+                        event="node_complete",
+                        data={"id": nid, "confidence": evt["data"].get("confidence", 50), "metadata": {"sector": evt["data"].get("sector", "general")}},
+                        id=f"layer:{layer}:node:{idx}:done",
+                    ))
+
+        # Parse full response for node/edge construction
+        parsed = parse_json_response(full_text)
+        if isinstance(parsed, dict) and parsed.get("effects"):
+            effect_nodes, fetch_nodes, effect_edges, fetch_edges = _build_thinker_output(
+                parsed["effects"], parent_nodes, news_pool, layer
+            )
+
+    except asyncio.CancelledError:
+        log.info("Streaming cancelled for session %s at layer %d", session_id, layer)
+        raise
+    except Exception as e:
+        log.error("Streaming thinker failed at layer %d: %s", layer, e)
+        await queue.put(SSEEvent(event="error", data={"message": str(e), "layer": layer}))
+        return _empty_layer_result(f"Streaming thinker failed: {e}")
+
+    if not effect_nodes:
+        return _empty_layer_result("Thinker produced no effects")
+
+    all_edges = list(effect_edges) + list(fetch_edges)
+
+    # --- Matcher (batch) ---
+    opportunity_nodes = []
+    matcher_tokens = 0
+    try:
+        opportunity_nodes, match_edges, matcher_tokens = await _call_with_retry(
+            run_matcher, effects=effect_nodes, value_pool=value_pool,
+        )
+        all_edges.extend(match_edges)
+        # Push opportunity nodes as batch (non-streaming)
+        for opp in opportunity_nodes:
+            await queue.put(SSEEvent(
+                event="node_start",
+                data={"id": opp["id"], "layer": opp["layer"], "type": "opportunity", "parent_ids": opp.get("parents", [])},
+            ))
+            await queue.put(SSEEvent(
+                event="node_complete",
+                data={"id": opp["id"], "confidence": opp.get("confidence", 0), "metadata": opp.get("metadata", {})},
+            ))
+    except Exception as e:
+        log.warning("Matcher failed at layer %d: %s", layer, e)
+
+    # Push edges
+    await queue.put(SSEEvent(event="edges", data=all_edges, id=f"layer:{layer}:edges"))
+
+    # --- Controller (batch) ---
+    controller_tokens = 0
+    try:
+        ctrl, controller_tokens = await _call_with_retry(
+            run_controller,
+            chain_summary=chain_summary,
+            effects=effect_nodes,
+            matches=opportunity_nodes,
+            layer=layer,
+            max_depth=max_depth,
+            confidence_threshold=confidence_threshold,
+        )
+    except Exception as e:
+        log.warning("Controller failed at layer %d: %s", layer, e)
+        should_continue = layer < DEFAULT_STOP_LAYER
+        ctrl = {"continue": should_continue, "reasoning": f"Controller failed: {e}", "summary": chain_summary}
+
+    await queue.put(SSEEvent(
+        event="layer_complete",
+        data={"layer": layer, "controller": ctrl},
+        id=f"layer:{layer}:complete",
+    ))
+
+    return LayerResult(
+        effect_nodes=effect_nodes,
+        fetch_nodes=fetch_nodes,
+        opportunity_nodes=opportunity_nodes,
+        all_edges=all_edges,
+        controller_decision=ctrl,
+        tokens_used={"thinker": thinker_tokens, "matcher": matcher_tokens, "controller": controller_tokens},
+    )
+```
+
+Also add at top of `thinking_service.py`:
+
+```python
+from uuid import uuid4
+from src.services.stream_parser import IncrementalEffectsParser
+from src.services.session_events import SessionRegistry, SSEEvent
+from src.agents.thinking_helpers import parse_json_response
+
+# Alias for mockability in tests
+try:
+    from litellm import acompletion as litellm_acompletion
+except ImportError:
+    litellm_acompletion = None  # type: ignore
+```
+
+- [ ] **Step 4: Run test — verify it passes**
+
+```bash
+cd /path/to/worktree && docker compose run --rm --no-deps backend python -m pytest tests/test_streaming_layer.py -v
+```
+
+- [ ] **Step 5: Run all existing tests — verify no regressions**
+
+```bash
+cd /path/to/worktree && docker compose run --rm --no-deps backend python -m pytest tests/ -v --ignore=tests/benchmark
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add backend/src/services/thinking_service.py backend/tests/test_streaming_layer.py
+git commit -m "feat(sse): add streaming layer runner with LiteLLM + incremental parser"
+```
+
+---
+
+## Task 5: SSE Endpoint + Auto-Run Integration
+
+**Files:**
+- Modify: `backend/src/api/thinking_auto.py` (replace polling SSE, integrate registry)
+- Test: `backend/tests/test_sse_endpoint.py`
+- Depends on: Task 1, Task 4
+
+- [ ] **Step 1: Write failing tests**
+
+```python
+# backend/tests/test_sse_endpoint.py
+import asyncio
+import pytest
+from unittest.mock import patch, AsyncMock
+from httpx import AsyncClient, ASGITransport
+from src.main import app
+from src.services.session_events import registry, SSEEvent
+
+
+@pytest.mark.asyncio
+async def test_sse_endpoint_streams_events():
+    """SSE endpoint delivers events from session queue."""
+    # Pre-register a session
+    dummy_task = asyncio.ensure_future(asyncio.sleep(100))
+    entry = registry.create("test-sse", dummy_task)
+
+    # Push some events
+    await entry.queue.put(SSEEvent(event="node_start", data={"id": "n1", "layer": 1, "type": "effect"}, id="layer:1:node:0"))
+    await entry.queue.put(SSEEvent(event="session_complete", data={"status": "complete"}, id="session:complete"))
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        async with client.stream("GET", "/api/thinking/test-sse/events") as resp:
+            assert resp.status_code == 200
+            lines = []
+            async for line in resp.aiter_lines():
+                lines.append(line)
+                if "session_complete" in line:
+                    break
+            text = "\n".join(lines)
+            assert "node_start" in text
+            assert "session_complete" in text
+
+    registry.remove("test-sse")
+    dummy_task.cancel()
+
+
+@pytest.mark.asyncio
+async def test_sse_endpoint_unknown_session_replays_from_db():
+    """Unknown session falls back to MongoDB replay."""
+    # Mock MongoDB find
+    mock_session = {
+        "id": "old-sess",
+        "status": "complete",
+        "current_layer": 2,
+        "nodes": [{"id": "n1", "layer": 1, "type": "effect", "content": "X", "reasoning": "", "sources": [], "parents": ["s1"], "selected": True, "metadata": {}}],
+        "edges": [{"source": "s1", "target": "n1", "relationship": "causes"}],
+    }
+
+    with patch("src.api.thinking_auto.mongodb") as mock_db:
+        col = AsyncMock()
+        col.find_one = AsyncMock(return_value=mock_session)
+        mock_db.get_collection.return_value = col
+
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            async with client.stream("GET", "/api/thinking/old-sess/events") as resp:
+                assert resp.status_code == 200
+                lines = []
+                async for line in resp.aiter_lines():
+                    lines.append(line)
+                    if "session_complete" in line:
+                        break
+                text = "\n".join(lines)
+                assert "session_complete" in text
+```
+
+- [ ] **Step 2: Run tests — verify they fail**
+
+```bash
+cd /path/to/worktree && docker compose run --rm --no-deps backend python -m pytest tests/test_sse_endpoint.py -v
+```
+
+- [ ] **Step 3: Rewrite thinking_auto.py**
+
+Replace the full file. Key changes:
+1. `auto_think()`: Create queue in registry **before** `create_task()`. Pipeline loop calls `run_layer_streaming()` and pushes `session_complete` event when done.
+2. `session_events()`: Read from queue if session is active; replay from MongoDB if session is complete/unknown. Cancels pipeline on client disconnect.
+3. Health check background task started via FastAPI `on_event("startup")`.
+4. Add `from fastapi import APIRouter, Request` import for disconnect detection.
+
+**auto_think rewrite — pipeline loop integration:**
+
+```python
+from fastapi import APIRouter, Request
+from src.services.session_events import registry, SSEEvent
+from src.services.thinking_service import run_layer_streaming, LayerResult
+
+@router.post("/auto", response_model=StartResponse)
+async def auto_think(req: StartRequest):
+    session_id = uuid4().hex[:12]
+    # ... (pool loading + session creation same as before, lines 26-93) ...
+    await col.insert_one(session)
+
+    async def _run_streaming_pipeline():
+        """Streaming pipeline loop — pushes events to queue via run_layer_streaming."""
+        chain_summary = ""
+        all_layer_nodes: list[list[dict]] = [nodes]  # layer 0 = seeds
+
+        try:
+            for layer in range(1, req.max_depth + 1):
+                parent_nodes = []
+                for layer_nodes in all_layer_nodes:
+                    parent_nodes.extend(n for n in layer_nodes if n.get("selected", False))
+
+                result = await run_layer_streaming(
+                    session_id=session_id,
+                    chain_summary=chain_summary,
+                    parent_nodes=parent_nodes,
+                    news_pool=news_items,
+                    value_pool=value_items,
+                    layer=layer,
+                    max_depth=req.max_depth,
+                    registry=registry,
+                )
+
+                # Persist to MongoDB (same as before)
+                new_nodes = result.effect_nodes + result.fetch_nodes + result.opportunity_nodes
+                update: dict = {"$set": {"current_layer": layer, "status": "thinking"}}
+                if new_nodes:
+                    update["$push"] = {"nodes": {"$each": new_nodes}, "edges": {"$each": result.all_edges}}
+                await col.update_one({"id": session_id}, update)
+
+                all_layer_nodes.append(new_nodes)
+                chain_summary = result.controller_decision.get("summary", chain_summary)
+
+                if not result.controller_decision.get("continue", False):
+                    break
+
+            await col.update_one({"id": session_id}, {"$set": {"status": "complete"}})
+            entry = registry.get(session_id)
+            if entry:
+                await entry.queue.put(SSEEvent(event="session_complete", data={"status": "complete"}, id="session:complete"))
+
+        except asyncio.CancelledError:
+            log.info("Pipeline cancelled for session %s", session_id)
+            await col.update_one({"id": session_id}, {"$set": {"status": "cancelled"}})
+            entry = registry.get(session_id)
+            if entry:
+                await entry.queue.put(SSEEvent(event="session_complete", data={"status": "cancelled"}))
+        except asyncio.TimeoutError:
+            await col.update_one({"id": session_id}, {"$set": {"status": "timeout"}})
+            entry = registry.get(session_id)
+            if entry:
+                await entry.queue.put(SSEEvent(event="error", data={"message": "Pipeline timeout"}))
+        except Exception as e:
+            log.error("Pipeline failed: %s", e)
+            await col.update_one({"id": session_id}, {"$set": {"status": "error", "error": str(e)}})
+            entry = registry.get(session_id)
+            if entry:
+                await entry.queue.put(SSEEvent(event="error", data={"message": str(e)}))
+
+    # Create queue BEFORE launching task — guarantees no lost events
+    task = asyncio.create_task(
+        asyncio.wait_for(_run_streaming_pipeline(), timeout=PIPELINE_TIMEOUT_S)
+    )
+    registry.create(session_id, task)
+
+    return StartResponse(session_id=session_id, status="thinking")
+```
+
+**SSE endpoint — with disconnect detection and cancellation:**
+
+```python
+@router.get("/{session_id}/events")
+async def session_events(session_id: str, request: Request):
+    entry = registry.get(session_id)
+
+    if entry:
+        # Live session — stream from queue
+        async def live_stream():
+            try:
+                while True:
+                    # Check if client disconnected
+                    if await request.is_disconnected():
+                        log.info("SSE client disconnected for %s — cancelling pipeline", session_id)
+                        registry.remove(session_id)  # cancels the task
+                        return
+                    try:
+                        event = await asyncio.wait_for(entry.queue.get(), timeout=1.0)
+                    except asyncio.TimeoutError:
+                        # Send keepalive comment to detect disconnects
+                        yield ": keepalive\n\n"
+                        continue
+                    yield event.serialize()
+                    if event.event in ("session_complete", "error"):
+                        break
+            except asyncio.CancelledError:
+                pass
+            finally:
+                # Clean up registry if pipeline is done
+                if entry.task and entry.task.done():
+                    registry.remove(session_id)
+        return StreamingResponse(live_stream(), media_type="text/event-stream")
+    else:
+        # Completed/unknown session — replay from MongoDB
+        async def replay_stream():
+            col = mongodb.get_collection("thinking_sessions")
+            session = await col.find_one({"id": session_id}, {"_id": 0})
+            if not session:
+                yield SSEEvent(event="error", data={"message": "Session not found"}).serialize()
+                return
+            for i, node in enumerate(session.get("nodes", [])):
+                yield SSEEvent(event="node_start", data=node, id=f"replay:node:{i}").serialize()
+                yield SSEEvent(event="node_complete", data={"id": node["id"], "confidence": node.get("confidence", 0)}, id=f"replay:node:{i}:done").serialize()
+            yield SSEEvent(event="edges", data=session.get("edges", []), id="replay:edges").serialize()
+            yield SSEEvent(event="session_complete", data={"status": session.get("status", "complete")}, id="session:complete").serialize()
+        return StreamingResponse(replay_stream(), media_type="text/event-stream")
+```
+
+**Health check — register on startup via main.py:**
+
+Add to `backend/src/main.py` in the `lifespan` or `on_event("startup")`:
+
+```python
+from src.services.session_events import registry
+
+async def _periodic_health_check():
+    while True:
+        await asyncio.sleep(30)
+        await registry.health_check()
+
+@app.on_event("startup")
+async def start_health_check():
+    asyncio.create_task(_periodic_health_check())
+```
+
+- [ ] **Step 4: Run tests — verify they pass**
+
+```bash
+cd /path/to/worktree && docker compose run --rm --no-deps backend python -m pytest tests/test_sse_endpoint.py -v
+```
+
+- [ ] **Step 5: Run all backend tests — no regressions**
+
+```bash
+cd /path/to/worktree && docker compose run --rm --no-deps backend python -m pytest tests/ -v --ignore=tests/benchmark
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add backend/src/api/thinking_auto.py backend/tests/test_sse_endpoint.py
+git commit -m "feat(sse): queue-based SSE endpoint with live streaming + DB replay"
+```
+
+---
+
+## Task 6: Frontend — SSE Types + Concentric Layout
+
+**Files:**
+- Modify: `frontend/src/types/thinking.ts` (update SSE event types)
+- Modify: `frontend/src/lib/thinking-graph-builder.ts` (add `concentricPosition()`)
+- Test: `frontend/src/lib/__tests__/concentric-layout.test.ts`
+
+- [ ] **Step 1: Update SSE event types**
+
+Replace lines 39-45 of `frontend/src/types/thinking.ts`:
+
+```typescript
+// SSE event types — matches backend event protocol
+export interface SSENodeStart {
+  id: string;
+  layer: number;
+  type: ThinkingNodeType;
+  parent_ids: string[];
+}
+
+export interface SSENodeText {
+  id: string;
+  field: "content" | "reasoning";
+  delta: string;
+}
+
+export interface SSENodeComplete {
+  id: string;
+  confidence: number;
+  metadata: Record<string, unknown>;
+}
+
+export interface SSELayerComplete {
+  layer: number;
+  controller: { continue: boolean; reasoning: string; summary: string };
+}
+
+export interface SSESessionComplete {
+  status: string;
+}
+
+export interface SSEError {
+  message: string;
+  layer?: number;
+}
+```
+
+- [ ] **Step 2: Add `concentricPosition()` to thinking-graph-builder.ts**
+
+Add after `nodeStyle()` (after line 58):
+
+```typescript
+/**
+ * Calculate deterministic position on a concentric ring.
+ * Used during SSE streaming — avoids d3-force re-simulation.
+ */
+export function concentricPosition(
+  layer: number,
+  index: number,
+  totalInLayer: number,
+  layerRadius: number = 180,
+): { x: number; y: number } {
+  if (layer === 0) {
+    // Seeds cluster near center
+    const angle = (index / Math.max(totalInLayer, 1)) * 2 * Math.PI;
+    const r = totalInLayer > 1 ? 60 : 0;
+    return { x: Math.cos(angle) * r, y: Math.sin(angle) * r };
+  }
+  const r = layer * layerRadius;
+  const angle =
+    (index / Math.max(totalInLayer, 1)) * 2 * Math.PI +
+    (layer * Math.PI) / 6; // Offset each ring to avoid radial alignment
+  return { x: Math.cos(angle) * r, y: Math.sin(angle) * r };
+}
+```
+
+- [ ] **Step 3: Write test for concentric layout**
+
+```typescript
+// frontend/src/lib/__tests__/concentric-layout.test.ts
+import { describe, it, expect } from "vitest";
+import { concentricPosition } from "../thinking-graph-builder";
+
+describe("concentricPosition", () => {
+  it("places layer 0 at center when single node", () => {
+    const pos = concentricPosition(0, 0, 1);
+    expect(pos.x).toBeCloseTo(0, 0);
+    expect(pos.y).toBeCloseTo(0, 0);
+  });
+
+  it("places layer 1 nodes on a ring", () => {
+    const pos = concentricPosition(1, 0, 4);
+    const dist = Math.sqrt(pos.x ** 2 + pos.y ** 2);
+    expect(dist).toBeCloseTo(180, 0);
+  });
+
+  it("spaces nodes evenly on ring", () => {
+    const positions = Array.from({ length: 4 }, (_, i) =>
+      concentricPosition(1, i, 4),
+    );
+    // All should be ~180px from center
+    for (const p of positions) {
+      expect(Math.sqrt(p.x ** 2 + p.y ** 2)).toBeCloseTo(180, 0);
+    }
+    // No two should overlap
+    for (let i = 0; i < positions.length; i++) {
+      for (let j = i + 1; j < positions.length; j++) {
+        const dx = positions[i].x - positions[j].x;
+        const dy = positions[i].y - positions[j].y;
+        expect(Math.sqrt(dx * dx + dy * dy)).toBeGreaterThan(50);
+      }
+    }
+  });
+
+  it("layer 2 has larger radius than layer 1", () => {
+    const p1 = concentricPosition(1, 0, 1);
+    const p2 = concentricPosition(2, 0, 1);
+    const r1 = Math.sqrt(p1.x ** 2 + p1.y ** 2);
+    const r2 = Math.sqrt(p2.x ** 2 + p2.y ** 2);
+    expect(r2).toBeGreaterThan(r1);
+  });
+});
+```
+
+- [ ] **Step 4: Run frontend tests**
+
+```bash
+cd /path/to/worktree/frontend && npx vitest run src/lib/__tests__/concentric-layout.test.ts
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add frontend/src/types/thinking.ts frontend/src/lib/thinking-graph-builder.ts frontend/src/lib/__tests__/concentric-layout.test.ts
+git commit -m "feat(sse): add SSE event types + deterministic concentric layout"
+```
+
+---
+
+## Task 7: Frontend — useSSESession Hook
+
+**Files:**
+- Create: `frontend/src/hooks/useSSESession.ts`
+- Test: `frontend/src/hooks/__tests__/useSSESession.test.ts`
+
+- [ ] **Step 1: Write failing test**
+
+```typescript
+// frontend/src/hooks/__tests__/useSSESession.test.ts
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+import { useSSESession } from "../useSSESession";
+
+// Mock EventSource
+class MockEventSource {
+  url: string;
+  listeners: Record<string, ((e: MessageEvent) => void)[]> = {};
+  readyState = 0;
+  close = vi.fn();
+
+  constructor(url: string) {
+    this.url = url;
+    this.readyState = 1; // OPEN
+  }
+
+  addEventListener(type: string, fn: (e: MessageEvent) => void) {
+    if (!this.listeners[type]) this.listeners[type] = [];
+    this.listeners[type].push(fn);
+  }
+
+  removeEventListener(type: string, fn: (e: MessageEvent) => void) {
+    this.listeners[type] = (this.listeners[type] || []).filter((f) => f !== fn);
+  }
+
+  emit(type: string, data: string, id?: string) {
+    const event = new MessageEvent(type, { data, lastEventId: id });
+    for (const fn of this.listeners[type] || []) fn(event);
+  }
+}
+
+let mockES: MockEventSource;
+vi.stubGlobal(
+  "EventSource",
+  vi.fn((url: string) => {
+    mockES = new MockEventSource(url);
+    return mockES;
+  }),
+);
+
+describe("useSSESession", () => {
+  it("connects to SSE endpoint", () => {
+    const { result } = renderHook(() => useSSESession("sess1"));
+    expect(mockES.url).toBe("/api/thinking/sess1/events");
+    expect(result.current.connected).toBe(true);
+  });
+
+  it("receives node_start events", () => {
+    const onNodeStart = vi.fn();
+    renderHook(() => useSSESession("sess1", { onNodeStart }));
+    act(() => {
+      mockES.emit("node_start", JSON.stringify({ id: "n1", layer: 1, type: "effect", parent_ids: ["s1"] }));
+    });
+    expect(onNodeStart).toHaveBeenCalledWith(expect.objectContaining({ id: "n1" }));
+  });
+
+  it("receives node_text events", () => {
+    const onNodeText = vi.fn();
+    renderHook(() => useSSESession("sess1", { onNodeText }));
+    act(() => {
+      mockES.emit("node_text", JSON.stringify({ id: "n1", field: "content", delta: "Fed " }));
+    });
+    expect(onNodeText).toHaveBeenCalledWith(expect.objectContaining({ delta: "Fed " }));
+  });
+
+  it("cleans up on unmount", () => {
+    const { unmount } = renderHook(() => useSSESession("sess1"));
+    unmount();
+    expect(mockES.close).toHaveBeenCalled();
+  });
+});
+```
+
+- [ ] **Step 2: Implement useSSESession.ts**
+
+```typescript
+// frontend/src/hooks/useSSESession.ts
+import { useEffect, useRef, useState, useCallback } from "react";
+import type {
+  SSENodeStart,
+  SSENodeText,
+  SSENodeComplete,
+  SSELayerComplete,
+  SSESessionComplete,
+  SSEError,
+} from "../types/thinking";
+import type { ThinkingEdge } from "../types/thinking";
+
+interface SSECallbacks {
+  onNodeStart?: (data: SSENodeStart) => void;
+  onNodeText?: (data: SSENodeText) => void;
+  onNodeComplete?: (data: SSENodeComplete) => void;
+  onEdges?: (data: ThinkingEdge[]) => void;
+  onLayerComplete?: (data: SSELayerComplete) => void;
+  onSessionComplete?: (data: SSESessionComplete) => void;
+  onError?: (data: SSEError) => void;
+}
+
+const MAX_RETRIES = 3;
+const RETRY_DELAY_MS = 5000;
+
+export function useSSESession(sessionId: string | null, callbacks?: SSECallbacks) {
+  const [connected, setConnected] = useState(false);
+  const esRef = useRef<EventSource | null>(null);
+  const retriesRef = useRef(0);
+  // Stabilize callbacks with ref — avoids reconnecting on every render
+  const cbRef = useRef(callbacks);
+  cbRef.current = callbacks;
+
+  const connect = useCallback(() => {
+    if (!sessionId) return;
+    const url = `/api/thinking/${sessionId}/events`;
+    const es = new EventSource(url);
+    esRef.current = es;
+
+    es.addEventListener("node_start", (e: MessageEvent) => {
+      cbRef.current?.onNodeStart?.(JSON.parse(e.data));
+    });
+    es.addEventListener("node_text", (e: MessageEvent) => {
+      cbRef.current?.onNodeText?.(JSON.parse(e.data));
+    });
+    es.addEventListener("node_complete", (e: MessageEvent) => {
+      cbRef.current?.onNodeComplete?.(JSON.parse(e.data));
+    });
+    es.addEventListener("edges", (e: MessageEvent) => {
+      cbRef.current?.onEdges?.(JSON.parse(e.data));
+    });
+    es.addEventListener("layer_complete", (e: MessageEvent) => {
+      cbRef.current?.onLayerComplete?.(JSON.parse(e.data));
+    });
+    es.addEventListener("session_complete", (e: MessageEvent) => {
+      cbRef.current?.onSessionComplete?.(JSON.parse(e.data));
+      es.close();
+      setConnected(false);
+    });
+    es.addEventListener("error", (e: MessageEvent) => {
+      if (e.data) {
+        cbRef.current?.onError?.(JSON.parse(e.data));
+      }
+    });
+
+    es.onopen = () => {
+      setConnected(true);
+      retriesRef.current = 0;
+    };
+    es.onerror = () => {
+      setConnected(false);
+      es.close();
+      if (retriesRef.current < MAX_RETRIES) {
+        retriesRef.current += 1;
+        setTimeout(connect, RETRY_DELAY_MS);
+      } else {
+        cbRef.current?.onError?.({ message: "SSE connection failed after retries" });
+      }
+    };
+  }, [sessionId]); // Only reconnect when sessionId changes, not on callback changes
+
+  useEffect(() => {
+    connect();
+    return () => {
+      esRef.current?.close();
+      setConnected(false);
+    };
+  }, [connect]);
+
+  return { connected };
+}
+```
+
+- [ ] **Step 3: Run tests**
+
+```bash
+cd /path/to/worktree/frontend && npx vitest run src/hooks/__tests__/useSSESession.test.ts
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add frontend/src/hooks/useSSESession.ts frontend/src/hooks/__tests__/useSSESession.test.ts
+git commit -m "feat(sse): add useSSESession hook with EventSource lifecycle + reconnection"
+```
+
+---
+
+## Task 8: Frontend — StreamingNode Component + Animation Queue
+
+**Files:**
+- Create: `frontend/src/components/StreamingNode.tsx`
+- Create: `frontend/src/hooks/useAnimationQueue.ts`
+
+- [ ] **Step 1: Implement StreamingNode.tsx**
+
+Custom React Flow node component that supports streaming text and entrance animations:
+
+```typescript
+// frontend/src/components/StreamingNode.tsx
+import { memo, useEffect, useState } from "react";
+import { Handle, Position, type NodeProps } from "@xyflow/react";
+
+interface StreamingNodeData {
+  label: string;
+  type: string;
+  layer: number;
+  selected: boolean;
+  reasoning: string;
+  streaming?: boolean; // True while text is still arriving
+  confidence?: number;
+}
+
+function StreamingNodeComponent({ data }: NodeProps) {
+  const d = data as unknown as StreamingNodeData;
+  const [visible, setVisible] = useState(false);
+
+  // Entrance animation — fade in after mount
+  useEffect(() => {
+    const timer = setTimeout(() => setVisible(true), 50);
+    return () => clearTimeout(timer);
+  }, []);
+
+  const isOpp = d.type === "opportunity";
+
+  return (
+    <div
+      style={{
+        opacity: visible ? 1 : 0,
+        transform: visible ? "scale(1)" : "scale(0.8)",
+        transition: "opacity 400ms ease-out, transform 400ms ease-out",
+      }}
+    >
+      <Handle type="target" position={Position.Top} style={{ opacity: 0 }} />
+      <div
+        style={{
+          fontSize: 12,
+          lineHeight: 1.5,
+          minWidth: 140,
+          maxWidth: 200,
+          padding: "10px 14px",
+        }}
+      >
+        <div>{d.label}</div>
+        {d.streaming && (
+          <span
+            className="inline-block w-1.5 h-3 ml-0.5 bg-current animate-pulse"
+            style={{ opacity: 0.6 }}
+          />
+        )}
+        {d.confidence != null && !d.streaming && (
+          <div
+            className="mt-1 text-[10px]"
+            style={{ color: isOpp ? "#86efac" : "#9ca3af" }}
+          >
+            {d.confidence}% confidence
+          </div>
+        )}
+      </div>
+      <Handle type="source" position={Position.Bottom} style={{ opacity: 0 }} />
+    </div>
+  );
+}
+
+export const StreamingNode = memo(StreamingNodeComponent);
+```
+
+- [ ] **Step 2: Implement useAnimationQueue.ts**
+
+```typescript
+// frontend/src/hooks/useAnimationQueue.ts
+import { useRef, useCallback } from "react";
+
+const MIN_GAP_MS = 200;
+
+/**
+ * Queues animation callbacks with a minimum gap between executions.
+ * Prevents visual clumping when multiple nodes arrive in quick succession.
+ */
+export function useAnimationQueue() {
+  const queue = useRef<(() => void)[]>([]);
+  const lastRun = useRef(0);
+  const timer = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const flush = useCallback(() => {
+    const now = Date.now();
+    const elapsed = now - lastRun.current;
+
+    if (queue.current.length === 0) return;
+
+    if (elapsed >= MIN_GAP_MS) {
+      const fn = queue.current.shift();
+      fn?.();
+      lastRun.current = Date.now();
+      // Schedule next if more in queue
+      if (queue.current.length > 0) {
+        timer.current = setTimeout(flush, MIN_GAP_MS);
+      }
+    } else {
+      // Wait for remaining gap
+      timer.current = setTimeout(flush, MIN_GAP_MS - elapsed);
+    }
+  }, []);
+
+  const enqueue = useCallback(
+    (fn: () => void) => {
+      queue.current.push(fn);
+      if (!timer.current) flush();
+    },
+    [flush],
+  );
+
+  return { enqueue };
+}
+```
+
+- [ ] **Step 3: Write tests for useAnimationQueue**
+
+```typescript
+// frontend/src/hooks/__tests__/useAnimationQueue.test.ts
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+import { useAnimationQueue } from "../useAnimationQueue";
+
+describe("useAnimationQueue", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  it("executes first callback immediately", () => {
+    const { result } = renderHook(() => useAnimationQueue());
+    const fn = vi.fn();
+    act(() => result.current.enqueue(fn));
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
+
+  it("enforces minimum gap between callbacks", () => {
+    const { result } = renderHook(() => useAnimationQueue());
+    const fn1 = vi.fn();
+    const fn2 = vi.fn();
+    act(() => {
+      result.current.enqueue(fn1);
+      result.current.enqueue(fn2);
+    });
+    expect(fn1).toHaveBeenCalledTimes(1);
+    expect(fn2).not.toHaveBeenCalled();
+    act(() => vi.advanceTimersByTime(200));
+    expect(fn2).toHaveBeenCalledTimes(1);
+  });
+
+  it("drains queue in order", () => {
+    const { result } = renderHook(() => useAnimationQueue());
+    const order: number[] = [];
+    act(() => {
+      result.current.enqueue(() => order.push(1));
+      result.current.enqueue(() => order.push(2));
+      result.current.enqueue(() => order.push(3));
+    });
+    act(() => vi.advanceTimersByTime(600));
+    expect(order).toEqual([1, 2, 3]);
+  });
+});
+```
+
+- [ ] **Step 4: Run tests**
+
+```bash
+cd /path/to/worktree/frontend && npx vitest run src/hooks/__tests__/useAnimationQueue.test.ts
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add frontend/src/components/StreamingNode.tsx frontend/src/hooks/useAnimationQueue.ts frontend/src/hooks/__tests__/useAnimationQueue.test.ts
+git commit -m "feat(sse): add StreamingNode component + animation queue hook with tests"
+```
+
+---
+
+## Task 9: Frontend — Integrate SSE into ThinkingView
+
+**Files:**
+- Modify: `frontend/src/components/ThinkingView.tsx`
+- Depends on: Task 6, 7, 8
+
+This is the integration task — wire `useSSESession` into `ThinkingView`, replacing the polling loop for auto-run mode.
+
+- [ ] **Step 1: Register StreamingNode type with React Flow**
+
+Add to ThinkingView.tsx imports:
+
+```typescript
+import { StreamingNode } from "./StreamingNode";
+```
+
+And define nodeTypes outside the component:
+
+```typescript
+const nodeTypes = { streaming: StreamingNode };
+```
+
+Pass to `<ReactFlow nodeTypes={nodeTypes} ...>`.
+
+- [ ] **Step 2: Add SSE integration alongside polling**
+
+In ThinkingView, add state for SSE mode and wire `useSSESession` callbacks:
+
+```typescript
+const [sseMode, setSseMode] = useState(false);
+const layerNodeCounts = useRef<Map<number, number>>(new Map());
+
+const handleNodeStart = useCallback((data: SSENodeStart) => {
+  const count = layerNodeCounts.current.get(data.layer) || 0;
+  layerNodeCounts.current.set(data.layer, count + 1);
+  const pos = concentricPosition(data.layer, count, count + 1);
+
+  setNodes((prev) => [
+    ...prev,
+    {
+      id: data.id,
+      type: "streaming",
+      position: pos,
+      data: {
+        label: "",
+        type: data.type,
+        layer: data.layer,
+        selected: true,
+        reasoning: "",
+        streaming: true,
+      },
+      style: nodeStyle(data.type, true, data.layer),
+    },
+  ]);
+}, [setNodes]);
+
+const handleNodeText = useCallback((data: SSENodeText) => {
+  setNodes((prev) =>
+    prev.map((n) => {
+      if (n.id !== data.id) return n;
+      const label = ((n.data as any).label || "") + data.delta;
+      return { ...n, data: { ...n.data, label } };
+    }),
+  );
+}, [setNodes]);
+
+// ... similar for onNodeComplete, onEdges, onSessionComplete
+```
+
+- [ ] **Step 3: Replace polling effect with SSE**
+
+Replace the polling `useEffect` (lines 174-180) with conditional logic:
+
+```typescript
+// Use SSE for auto-run, keep polling as fallback
+const { connected } = useSSESession(
+  session?.status === "thinking" ? sessionId : null,
+  {
+    onNodeStart: handleNodeStart,
+    onNodeText: handleNodeText,
+    onNodeComplete: handleNodeComplete,
+    onEdges: handleEdges,
+    onLayerComplete: handleLayerComplete,
+    onSessionComplete: handleSessionComplete,
+    onError: (err) => {
+      log.error("SSE error:", err.message);
+      // Fall back to polling
+      setSseMode(false);
+    },
+  },
+);
+
+// Polling fallback — only when SSE is not connected
+useEffect(() => {
+  if (connected || session?.status !== "thinking") return;
+  const interval = setInterval(() => loadSessionIncremental(), 2000);
+  return () => clearInterval(interval);
+}, [connected, session?.status, loadSessionIncremental]);
+```
+
+- [ ] **Step 4: Re-space existing nodes when siblings arrive**
+
+When a new node arrives on a ring, update positions of existing same-layer nodes:
+
+```typescript
+const handleNodeStart = useCallback((data: SSENodeStart) => {
+  const count = (layerNodeCounts.current.get(data.layer) || 0) + 1;
+  layerNodeCounts.current.set(data.layer, count);
+
+  // Re-space all nodes on this layer
+  setNodes((prev) => {
+    const updated = prev.map((n) => {
+      if ((n.data as any).layer !== data.layer) return n;
+      const idx = prev.filter((p) => (p.data as any).layer === data.layer).indexOf(n);
+      const pos = concentricPosition(data.layer, idx, count);
+      return { ...n, position: pos };
+    });
+
+    // Add the new node
+    const pos = concentricPosition(data.layer, count - 1, count);
+    updated.push({
+      id: data.id,
+      type: "streaming",
+      position: pos,
+      data: {
+        label: "",
+        type: data.type,
+        layer: data.layer,
+        selected: true,
+        reasoning: "",
+        streaming: true,
+      },
+      style: nodeStyle(data.type, true, data.layer),
+    });
+
+    return updated;
+  });
+}, [setNodes]);
+```
+
+- [ ] **Step 5: Manual verification**
+
+Start the app with Docker, run auto-think, and verify:
+- Nodes appear one-by-one with entrance animation
+- Content text streams word-by-word
+- Edges draw in after both endpoints exist
+- Fallback to polling works if SSE disconnects
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add frontend/src/components/ThinkingView.tsx
+git commit -m "feat(sse): integrate SSE streaming into ThinkingView with animation"
+```
+
+---
+
+## Task 10: Vite Proxy Fix (from earlier session)
+
+**Files:**
+- Modify: `frontend/vite.config.ts` (already modified but uncommitted)
+
+- [ ] **Step 1: Verify the fix is still in place**
+
+```bash
+cat frontend/vite.config.ts
+```
+
+Should show `process.env.VITE_API_URL || ...` on the apiTarget line.
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add frontend/vite.config.ts
+git commit -m "fix: read VITE_API_URL for Docker proxy target"
+```
+
+---
+
+## Task 11: E2E Verification
+
+- [ ] **Step 1: Rebuild and start Docker**
+
+```bash
+docker compose up --build -d
+```
+
+- [ ] **Step 2: Verify SSE endpoint works**
+
+```bash
+curl -N "http://localhost:3000/api/thinking/auto" -X POST -H "Content-Type: application/json" -d '{"date":"2026-03-26","market":"US","max_depth":2}'
+# Note the session_id
+
+curl -N "http://localhost:3000/api/thinking/{session_id}/events"
+# Should see streaming SSE events
+```
+
+- [ ] **Step 3: Open browser and test**
+
+Open http://localhost:3000, click auto-run, verify:
+- Nodes appear progressively (not all at once)
+- Text streams word-by-word
+- Edges draw in
+- Session completes successfully
+
+- [ ] **Step 4: Test fallback — kill SSE mid-stream, verify polling resumes**
+
+---
+
+## Dependency Graph
+
+```
+Task 1 (session_events) ─┐
+Task 2 (stream_parser) ──┤
+Task 3 (llm_config) ─────┼── Task 4 (streaming layer) ── Task 5 (SSE endpoint) ──┐
+                          │                                                        │
+Task 6 (types + layout) ─┤                                                        │
+Task 7 (useSSESession) ──┼──────────────────── Task 9 (ThinkingView integration) ─┤
+Task 8 (StreamingNode) ──┘                                                        │
+                                                                                   │
+Task 10 (vite proxy fix) ─────────────────────────── Task 11 (E2E verification) ──┘
+```
+
+Tasks 1, 2, 3, 6, 7, 8, 10 are independent and can run in parallel.
+Task 4 depends on 1, 2, 3.
+Task 5 depends on 4.
+Task 9 depends on 6, 7, 8.
+Task 11 depends on 5, 9, 10.

--- a/docs/superpowers/plans/macro-news-pipeline/tasks-1-3.md
+++ b/docs/superpowers/plans/macro-news-pipeline/tasks-1-3.md
@@ -1,0 +1,315 @@
+# Tasks 1-3: Foundation (Model + Scoring + Pipeline Infrastructure)
+
+Back to [[2026-03-24-macro-news-pipeline]]
+
+---
+
+### Task 1: Data Model + Config Changes
+
+**Files:**
+- Modify: `backend/src/models/news_entity.py`
+- Modify: `backend/src/core/config.py`
+- Test: `backend/tests/test_news_entity_model.py`
+
+- [ ] **Step 1: Write failing test for new NewsEntity fields**
+
+```python
+# backend/tests/test_news_entity_model.py
+from src.models.news_entity import NewsEntity
+
+
+def test_news_entity_has_scope_field():
+    e = NewsEntity(id="t1", canonical_title="Test", summary="s")
+    assert e.scope == 2  # default
+
+
+def test_news_entity_has_origin_field():
+    e = NewsEntity(id="t1", canonical_title="Test", summary="s")
+    assert e.origin == "perigon"
+
+
+def test_news_entity_has_story_cluster_size():
+    e = NewsEntity(id="t1", canonical_title="Test", summary="s")
+    assert e.story_cluster_size == 1
+```
+
+**Note:** Do NOT remove `market` field yet — that happens in Task 3 alongside the pipeline infrastructure changes. Removing it here would break `test_fetch_placeholder_empty` and `_gen_id` before they're updated.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd backend && python -m pytest tests/test_news_entity_model.py -v`
+Expected: FAIL — `scope`, `origin`, `story_cluster_size` not found
+
+- [ ] **Step 3: Update NewsEntity model — add new fields only**
+
+In `backend/src/models/news_entity.py`, add three new fields (keep `market` for now):
+
+```python
+class NewsEntity(BaseModel):
+    id: str
+    canonical_title: str
+    summary: str
+    sources: list[str] = Field(default_factory=list)
+    tickers: list[str] = Field(default_factory=list)
+    sectors: list[str] = Field(default_factory=list)
+    named_entities: list[str] = Field(default_factory=list)
+    embedding: list[float] = Field(default_factory=list)
+    scope: int = 2
+    score: float = 0.0
+    score_factors: dict[str, float] = Field(default_factory=dict)
+    first_seen_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
+    last_seen_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
+    status: EntityStatus = EntityStatus.ACTIVE
+    market: str = "US"          # KEPT until Task 3
+    origin: str = "perigon"
+    story_cluster_size: int = 1
+```
+
+- [ ] **Step 4: Update config with new fields**
+
+In `backend/src/core/config.py`, add to `Settings`:
+
+```python
+news_macro_quota_ratio: float = 0.4
+newsapi_api_key: str = ""
+newsapi_daily_limit: int = 100
+newsapi_agent_daily_cap: int = 50
+perigon_agent_daily_cap: int = 2
+```
+
+- [ ] **Step 5: Run ALL tests to verify no regressions**
+
+Run: `cd backend && python -m pytest tests/test_news_entity_model.py tests/test_news_pipeline.py -v`
+Expected: ALL PASS (new tests pass, existing tests unbroken)
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add backend/src/models/news_entity.py backend/src/core/config.py backend/tests/test_news_entity_model.py
+git commit -m "feat: add scope/origin/cluster_size to NewsEntity"
+```
+
+---
+
+### Task 2: Scoring Redesign
+
+**Files:**
+- Modify: `backend/src/pipelines/news/score.py`
+- Modify: `backend/tests/test_news_pipeline.py`
+
+- [ ] **Step 1: Write failing tests for new scoring formula**
+
+Add to `backend/tests/test_news_pipeline.py`:
+
+```python
+def test_macro_news_scores_higher_than_company_news():
+    """Macro news (scope=5, cluster=25) should outscore company news (scope=1, cluster=1)."""
+    scorer = NewsDecayScore()
+    macro = _entity(age_days=1, sources=3, scope=5, story_cluster_size=25)
+    company = _entity(age_days=1, sources=2, scope=1, story_cluster_size=1)
+    company["tickers"] = ["AAPL"]
+    assert scorer.score(macro).score > scorer.score(company).score
+
+
+def test_scope_factor_in_score_factors():
+    scorer = NewsDecayScore()
+    e = _entity(age_days=0, sources=1, scope=4)
+    result = scorer.score(e)
+    assert "scope_factor" in result.factors
+    assert "cluster_factor" in result.factors
+    assert "ticker_relevance" not in result.factors
+
+
+def test_cluster_factor_maxes_at_20():
+    scorer = NewsDecayScore()
+    e = _entity(age_days=0, sources=1, scope=3, story_cluster_size=50)
+    result = scorer.score(e)
+    assert result.factors["cluster_factor"] == 1.0
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd backend && python -m pytest tests/test_news_pipeline.py -v -k "macro_news or scope_factor or cluster_factor"`
+Expected: FAIL
+
+- [ ] **Step 3: Rewrite scoring formula**
+
+Replace `backend/src/pipelines/news/score.py` with new formula:
+- Weights: `0.4 * freshness + 0.25 * source_count + 0.2 * scope_factor + 0.15 * cluster_factor`
+- `_scope_factor`: `scope / 5.0`
+- `_cluster_factor`: `min(1.0, story_cluster_size / 20)`
+- Remove `_ticker_factor` entirely
+
+- [ ] **Step 4: Update `_entity` factory and existing tests**
+
+In `backend/tests/test_news_pipeline.py`:
+
+**a) Update `_entity()` factory** — add `scope` and `story_cluster_size` defaults:
+
+```python
+def _entity(age_days=0, sources=1, tickers=1, scope=2, story_cluster_size=1):
+    dt = (datetime.now(timezone.utc) - timedelta(days=age_days)).isoformat()
+    return {
+        "first_seen_at": dt, "last_seen_at": dt,
+        "sources": [f"s{i}" for i in range(sources)],
+        "tickers": [f"T{i}" for i in range(tickers)],
+        "scope": scope, "story_cluster_size": story_cluster_size,
+    }
+```
+
+**b) Update these existing tests** (score ranges shifted due to new weights):
+
+- `test_fresh_news_high_score` (line 19): Old formula gave ~68 for 1 source + 1 ticker. New formula: `0.4*1.0 + 0.25*0.4 + 0.2*0.4 + 0.15*0.05 = 0.5875 → 58.8`. Change assertion from `>= 60` to `>= 50`.
+- `test_old_news_low_score` (line 25): Old threshold `< 30` still holds — freshness dominates decay. Keep as-is but verify.
+- `test_multi_source_boost` (line 35): `source_count` factor unchanged in calculation, assertion `> 0.5` still holds. Keep as-is.
+- `test_no_tickers` (line 40): Change from `r.factors.get("ticker_relevance", 0) == 0.0` to `assert "ticker_relevance" not in r.factors` and add `assert "scope_factor" in r.factors`.
+- `test_fetch_placeholder_empty` (line 121): Import `AlphaVantageNewsFetch` will fail after Task 6 rewrites `fetch.py`. For now, leave as-is — it'll be updated in Task 6.
+
+- [ ] **Step 5: Run all scoring tests**
+
+Run: `cd backend && python -m pytest tests/test_news_pipeline.py -v`
+Expected: ALL PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add backend/src/pipelines/news/score.py backend/tests/test_news_pipeline.py
+git commit -m "feat: scoring formula — scope_factor + cluster_factor replace ticker_relevance"
+```
+
+---
+
+### Task 3: Pipeline Infrastructure (market-optional) + Remove market from NewsEntity
+
+**Files:**
+- Modify: `backend/src/models/news_entity.py` (remove `market` field)
+- Modify: `backend/src/models/pool_common.py`
+- Modify: `backend/src/pipelines/base.py`
+- Modify: `backend/src/pipelines/news/process.py`
+- Modify: `backend/src/database/repositories/news_entity_repo.py`
+- Test: `backend/tests/test_news_pipeline.py`
+
+- [ ] **Step 1: Write failing test for market-free ID generation**
+
+Add to `backend/tests/test_news_pipeline.py`:
+
+```python
+def test_gen_id_no_market():
+    """ID generation should not include market."""
+    proc = HybridSimilarityProcess()
+    raw = {"title": "Test headline", "date": "2026-03-24"}
+    id1 = proc._gen_id(raw)
+    raw_with_market = {"title": "Test headline", "date": "2026-03-24", "market": "CN"}
+    id2 = proc._gen_id(raw_with_market)
+    assert id1 == id2  # Market should not affect ID
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd backend && python -m pytest tests/test_news_pipeline.py::test_gen_id_no_market -v`
+Expected: FAIL — IDs differ because current impl includes market in hash
+
+- [ ] **Step 3: Update FetchStrategy protocol**
+
+In `backend/src/models/pool_common.py`:
+
+```python
+@runtime_checkable
+class FetchStrategy(Protocol):
+    async def fetch(self, market: str | None = None) -> list[dict]: ...
+```
+
+- [ ] **Step 4: Update PoolPipeline — market optional**
+
+In `backend/src/pipelines/base.py`, change `__init__` signature:
+
+```python
+def __init__(self, fetch, process, score, retain, repo, market: str | None = None):
+```
+
+And in `run()`:
+
+```python
+raw_items = await self.fetch.fetch(self.market)
+existing = await self.repo.get_all(market=self.market, include_stale=True)
+```
+
+(These already pass `self.market`, which will now be `None` for news.)
+
+- [ ] **Step 5: Update NewsEntityRepo — optional market**
+
+In `backend/src/database/repositories/news_entity_repo.py`:
+
+```python
+async def get_active(self, market: str | None = None) -> list[dict]:
+    q: dict = {"status": "active"}
+    if market is not None:
+        q["market"] = market
+    cursor = self.collection.find(q, {"_id": 0})
+    return await cursor.to_list(length=None)
+
+async def get_all(self, market: str | None = None, include_stale: bool = False) -> list[dict]:
+    q: dict = (
+        {"status": {"$in": ["active", "stale"]}} if include_stale
+        else {"status": "active"}
+    )
+    if market is not None:
+        q["market"] = market
+    return await self.collection.find(q, {"_id": 0}).to_list(length=None)
+```
+
+- [ ] **Step 6: Remove market from _gen_id**
+
+In `backend/src/pipelines/news/process.py`:
+
+```python
+def _gen_id(self, raw: dict) -> str:
+    title = raw.get("title", "")
+    date = raw.get("date", datetime.now(timezone.utc).strftime("%Y-%m-%d"))
+    return hashlib.sha256(f"{title}:{date}".encode()).hexdigest()[:16]
+```
+
+- [ ] **Step 7: Remove `market` field from NewsEntity**
+
+In `backend/src/models/news_entity.py`, remove the `market: str = "US"` line that was kept in Task 1.
+
+- [ ] **Step 8: Update `test_fetch_placeholder_empty`**
+
+The `AlphaVantageNewsFetch` class will be replaced in Task 6. For now, update the test to use `market=None`:
+
+```python
+@pytest.mark.asyncio
+async def test_fetch_placeholder_empty():
+    r = await AlphaVantageNewsFetch().fetch(market=None)
+    assert isinstance(r, list) and len(r) == 0
+```
+
+Also update `AlphaVantageNewsFetch.fetch` signature to accept optional market:
+
+```python
+class AlphaVantageNewsFetch:
+    async def fetch(self, market: str | None = None) -> list[dict]:
+        return []
+```
+
+- [ ] **Step 9: Add MongoDB index on `scope` field**
+
+Add to the repo or a migration helper:
+
+```python
+# In news_entity_repo.py __init__ or a startup hook:
+await self.collection.create_index("scope")
+await self.collection.create_index("status")
+```
+
+- [ ] **Step 10: Run all tests**
+
+Run: `cd backend && python -m pytest tests/test_news_pipeline.py tests/test_news_entity_model.py -v`
+Expected: ALL PASS
+
+- [ ] **Step 11: Commit**
+
+```bash
+git add backend/src/models/news_entity.py backend/src/models/pool_common.py backend/src/pipelines/base.py backend/src/pipelines/news/process.py backend/src/pipelines/news/fetch.py backend/src/database/repositories/news_entity_repo.py backend/tests/test_news_pipeline.py
+git commit -m "feat: make market optional in pipeline, remove market from NewsEntity"
+```

--- a/docs/superpowers/plans/macro-news-pipeline/tasks-4-6.md
+++ b/docs/superpowers/plans/macro-news-pipeline/tasks-4-6.md
@@ -1,0 +1,249 @@
+# Tasks 4-6: Fetch Sources (NewsAPI + Perigon Stories + Composite)
+
+Back to [[2026-03-24-macro-news-pipeline]]
+
+---
+
+### Task 4: NewsAPI Client
+
+**Files:**
+- Create: `backend/src/services/newsapi.py`
+- Test: `backend/tests/test_newsapi_client.py`
+
+- [ ] **Step 1: Write failing tests for NewsAPI normalization**
+
+```python
+# backend/tests/test_newsapi_client.py
+from src.services.newsapi import _newsapi_to_pool_item, _infer_scope_from_title, _infer_sectors_from_title
+
+
+def test_newsapi_to_pool_item_basic():
+    article = {
+        "title": "EU imposes new carbon tariffs on steel imports",
+        "source": {"name": "Reuters"},
+        "url": "https://reuters.com/article/123",
+        "description": "The European Union announced...",
+        "publishedAt": "2026-03-24T10:00:00Z",
+    }
+    item = _newsapi_to_pool_item(article)
+    assert item["id"].startswith("na-")
+    assert item["origin"] == "newsapi"
+    assert item["title"] == article["title"]
+    assert item["source"] == "Reuters"
+    assert item["story_cluster_size"] == 1
+
+
+def test_newsapi_to_pool_item_truncates_summary():
+    article = {
+        "title": "Test",
+        "source": {"name": "AP"},
+        "url": "https://example.com",
+        "description": "x" * 300,
+        "publishedAt": "2026-03-24T10:00:00Z",
+    }
+    item = _newsapi_to_pool_item(article)
+    assert len(item["summary"]) <= 200
+
+
+def test_infer_scope_geopolitical():
+    assert _infer_scope_from_title("NATO deploys troops to Baltic states") >= 4
+
+
+def test_infer_scope_company():
+    assert _infer_scope_from_title("Apple releases new iPhone model") <= 2
+
+
+def test_infer_sectors_from_title():
+    sectors = _infer_sectors_from_title("OPEC cuts oil production amid energy crisis")
+    assert any("energy" in s.lower() for s in sectors)
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd backend && python -m pytest tests/test_newsapi_client.py -v`
+Expected: FAIL — module `src.services.newsapi` does not exist
+
+- [ ] **Step 3: Create NewsAPI client**
+
+Create `backend/src/services/newsapi.py` with:
+- `_GEO_KEYWORDS`, `_MACRO_KEYWORDS`, `_SECTOR_MAP` — keyword sets for classification
+- `_infer_scope_from_title(title) -> int` — keyword-based scope 1-5
+- `_infer_sectors_from_title(title) -> list[str]` — keyword-based sector detection
+- `_newsapi_to_pool_item(article, origin="newsapi") -> dict` — normalizer
+- Rate limit tracking: `newsapi_usage` collection in MongoDB
+- Cache: `newsapi_cache` collection with same pattern as Perigon
+- `fetch_newsapi_headlines(category, language, page_size, daily_limit) -> list[dict]`
+- `fetch_newsapi_everything(query, sort_by, page_size, daily_limit) -> list[dict]`
+
+Both use `httpx.AsyncClient`, check cache first, enforce daily limits, return normalized pool items.
+
+- [ ] **Step 4: Run tests**
+
+Run: `cd backend && python -m pytest tests/test_newsapi_client.py -v`
+Expected: ALL PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/src/services/newsapi.py backend/tests/test_newsapi_client.py
+git commit -m "feat: NewsAPI client with headline + everything endpoints"
+```
+
+---
+
+### Task 5: Perigon Stories Fetch + Broadened Categories
+
+**Files:**
+- Modify: `backend/src/services/perigon.py`
+- Test: `backend/tests/test_perigon_stories.py`
+
+- [ ] **Step 1: Write failing test for stories normalization**
+
+```python
+# backend/tests/test_perigon_stories.py
+from src.services.perigon import _story_to_pool_item
+
+
+def test_story_to_pool_item_basic():
+    story = {
+        "storyId": "abc123",
+        "title": "China bans rare earth exports to US",
+        "summary": "Beijing announced...",
+        "numArticles": 42,
+        "initialPublishedAt": "2026-03-24T08:00:00Z",
+        "topics": [{"name": "Trade"}],
+        "categories": [{"name": "World"}],
+        "sentiment": {"positive": 0.1, "negative": 0.8},
+    }
+    item = _story_to_pool_item(story)
+    assert item["id"].startswith("pg-story-")
+    assert item["story_cluster_size"] == 42
+    assert item["origin"] == "perigon"
+    assert item["scope"] >= 4
+
+
+def test_story_cluster_size_preserved():
+    story = {
+        "storyId": "xyz",
+        "title": "Local city council vote",
+        "summary": "...",
+        "numArticles": 3,
+        "initialPublishedAt": "2026-03-24T08:00:00Z",
+        "topics": [],
+        "categories": [],
+        "sentiment": {},
+    }
+    item = _story_to_pool_item(story)
+    assert item["story_cluster_size"] == 3
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd backend && python -m pytest tests/test_perigon_stories.py -v`
+Expected: FAIL — `_story_to_pool_item` does not exist
+
+- [ ] **Step 3: Add `_story_to_pool_item` and `fetch_perigon_stories` to perigon.py**
+
+Add to `backend/src/services/perigon.py`:
+- `_story_to_pool_item(story) -> dict` — converts `/stories` response to pool format. Reuses existing `_classify_scope` for scope calculation. Stores `numArticles` as `story_cluster_size`. ID prefix: `pg-story-`.
+- `fetch_perigon_stories(categories, size, source_group) -> list[dict]` — hits `/v1/stories` endpoint with broad categories `["Politics", "World", "Environment", "Business", "Science"]`, `excludeLabel=["Opinion", "Non-news", "Paid News"]`, sorts by cluster size descending. Uses same cache/rate-limit pattern as `fetch_perigon_news`.
+
+Also broaden the default query in existing `fetch_perigon_news`:
+```python
+query: str = "economy markets geopolitical trade climate policy"
+```
+
+- [ ] **Step 4: Run tests**
+
+Run: `cd backend && python -m pytest tests/test_perigon_stories.py -v`
+Expected: ALL PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/src/services/perigon.py backend/tests/test_perigon_stories.py
+git commit -m "feat: Perigon /stories endpoint + broadened categories"
+```
+
+---
+
+### Task 6: Composite Fetch + Pipeline Wiring
+
+**Files:**
+- Rewrite: `backend/src/pipelines/news/fetch.py`
+- Modify: `backend/src/cron/scheduler.py`
+- Test: `backend/tests/test_composite_fetch.py`
+
+- [ ] **Step 1: Write failing test for CompositeFetch**
+
+```python
+# backend/tests/test_composite_fetch.py
+import pytest
+from src.pipelines.news.fetch import CompositeFetch
+
+
+class FakeFetcher:
+    def __init__(self, items: list[dict]):
+        self._items = items
+
+    async def fetch(self, market=None) -> list[dict]:
+        return self._items
+
+
+class FailingFetcher:
+    async def fetch(self, market=None) -> list[dict]:
+        raise RuntimeError("API down")
+
+
+@pytest.mark.asyncio
+async def test_composite_fetch_merges_results():
+    f1 = FakeFetcher([{"id": "a"}])
+    f2 = FakeFetcher([{"id": "b"}])
+    cf = CompositeFetch([f1, f2])
+    result = await cf.fetch()
+    assert len(result) == 2
+
+
+@pytest.mark.asyncio
+async def test_composite_fetch_survives_failure():
+    f1 = FakeFetcher([{"id": "a"}])
+    f2 = FailingFetcher()
+    cf = CompositeFetch([f1, f2])
+    result = await cf.fetch()
+    assert len(result) == 1
+    assert result[0]["id"] == "a"
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd backend && python -m pytest tests/test_composite_fetch.py -v`
+Expected: FAIL — `CompositeFetch` does not exist
+
+- [ ] **Step 3: Rewrite fetch.py**
+
+Replace `backend/src/pipelines/news/fetch.py` with:
+- `CompositeFetch` — takes list of fetchers, calls each with graceful error handling
+- `PerigonStoriesFetch` — wraps `fetch_perigon_stories()`
+- `PerigonAllFetch` — wraps `fetch_perigon_news()`
+- `NewsAPIHeadlinesFetch` — wraps `fetch_newsapi_headlines()`
+
+All fetchers implement `async def fetch(self, market=None) -> list[dict]`.
+
+- [ ] **Step 4: Update scheduler — single global news pipeline**
+
+In `backend/src/cron/scheduler.py`:
+- Update `build_news_pipeline()` — use `CompositeFetch([PerigonStoriesFetch(), PerigonAllFetch(), NewsAPIHeadlinesFetch()])`, pass `market=None`
+- Update `run_news_pipeline()` — remove market loop, run once globally
+- Update `_record_run` to accept `market: str | None`
+
+- [ ] **Step 5: Run all tests**
+
+Run: `cd backend && python -m pytest tests/test_composite_fetch.py tests/test_news_pipeline.py -v`
+Expected: ALL PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add backend/src/pipelines/news/fetch.py backend/src/cron/scheduler.py backend/tests/test_composite_fetch.py
+git commit -m "feat: composite fetch (stories + all + newsapi) + global pipeline"
+```

--- a/docs/superpowers/plans/macro-news-pipeline/tasks-7-10.md
+++ b/docs/superpowers/plans/macro-news-pipeline/tasks-7-10.md
@@ -1,0 +1,331 @@
+# Tasks 7-10: Integration (Agent Tool + API Layer + Verification)
+
+Back to [[2026-03-24-macro-news-pipeline]]
+
+---
+
+### Task 7: Agent `fetch_news` Tool
+
+**Files:**
+- Create: `backend/src/agents/tools/__init__.py`
+- Create: `backend/src/agents/tools/fetch_news.py`
+- Test: `backend/tests/test_fetch_news_tool.py`
+
+- [ ] **Step 1: Write failing test for fetch_news tool**
+
+```python
+# backend/tests/test_fetch_news_tool.py
+import pytest
+from unittest.mock import AsyncMock, patch
+from src.agents.tools.fetch_news import FetchNewsTool
+
+
+@pytest.mark.asyncio
+async def test_fetch_news_returns_results():
+    tool = FetchNewsTool()
+    with patch("src.agents.tools.fetch_news.fetch_perigon_news", new_callable=AsyncMock) as mock_pg, \
+         patch("src.agents.tools.fetch_news._has_api_budget", new_callable=AsyncMock) as mock_budget:
+        mock_budget.return_value = True
+        mock_pg.return_value = [{"id": "pg-123", "title": "Test news", "scope": 4}]
+        results = await tool.arun(query="rare earth supply chain")
+        assert len(results) == 1
+        assert results[0]["id"] == "pg-123"
+
+
+@pytest.mark.asyncio
+async def test_fetch_news_fallback_when_no_budget():
+    tool = FetchNewsTool()
+    with patch("src.agents.tools.fetch_news._has_api_budget", new_callable=AsyncMock) as mock_budget, \
+         patch("src.agents.tools.fetch_news._fallback_text_search", new_callable=AsyncMock) as mock_search:
+        mock_budget.return_value = False
+        mock_search.return_value = [{"id": "cached-1", "title": "Cached result"}]
+        results = await tool.arun(query="rare earth")
+        assert len(results) == 1
+        mock_search.assert_called_once()
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd backend && python -m pytest tests/test_fetch_news_tool.py -v`
+Expected: FAIL — module not found
+
+- [ ] **Step 3: Create agent tools package**
+
+```python
+# backend/src/agents/tools/__init__.py
+"""Agent tools — callable tools for agent reasoning."""
+```
+
+- [ ] **Step 4: Create FetchNewsTool**
+
+Create `backend/src/agents/tools/fetch_news.py` with:
+- `_has_api_budget() -> bool` — checks `perigon_usage` and `newsapi_usage` against daily caps from config
+- `_fallback_text_search(query, limit) -> list[dict]` — regex search on `canonical_title` in `news_entities` collection, sorted by score
+- `FetchNewsTool(BaseTool)`:
+  - `name = "fetch_news"`, description explains its purpose for the agent
+  - `_run(query)` — sync wrapper using `asyncio.run()` for CrewAI compatibility
+  - `arun(query)` — async impl: check budget → Perigon first → NewsAPI supplement → return results
+  - `max_results: int = 5`
+
+- [ ] **Step 5: Run tests**
+
+Run: `cd backend && python -m pytest tests/test_fetch_news_tool.py -v`
+Expected: ALL PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add backend/src/agents/tools/__init__.py backend/src/agents/tools/fetch_news.py backend/tests/test_fetch_news_tool.py
+git commit -m "feat: agent fetch_news tool — directed search with budget fallback"
+```
+
+---
+
+### Task 8: Thinker Agent Integration
+
+**Files:**
+- Modify: `backend/src/agents/thinking_crew.py`
+
+- [ ] **Step 1: Register FetchNewsTool in Thinker agent**
+
+In `backend/src/agents/thinking_crew.py`:
+- Add import: `from src.agents.tools.fetch_news import FetchNewsTool`
+- In the `run_thinker` function, find where the Thinker `Agent(...)` or `Task(tools=[...])` is created
+- Add `FetchNewsTool()` to the tools list
+
+- [ ] **Step 2: Verify existing tests still pass**
+
+Run: `cd backend && python -m pytest tests/ -v --timeout=30`
+Expected: ALL existing tests PASS (no regressions)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add backend/src/agents/thinking_crew.py
+git commit -m "feat: register fetch_news tool in Thinker agent"
+```
+
+---
+
+### Task 9: API Layer — Global Pool + Tiered Quota
+
+**Files:**
+- Create: `backend/src/pipelines/news/quota.py`
+- Modify: `backend/src/api/pools.py`
+- Modify: `backend/src/api/thinking.py`
+- Test: `backend/tests/test_tiered_quota.py`
+
+- [ ] **Step 1: Write failing test for tiered quota**
+
+```python
+# backend/tests/test_tiered_quota.py
+from src.pipelines.news.quota import apply_tiered_quota
+
+
+def test_tiered_quota_40_percent_macro():
+    items = [
+        {"id": f"macro-{i}", "scope": 5, "score": 90 - i} for i in range(3)
+    ] + [
+        {"id": f"company-{i}", "scope": 1, "score": 80 - i} for i in range(7)
+    ]
+    result = apply_tiered_quota(items, macro_ratio=0.4)
+    macro_count = sum(1 for r in result if r["scope"] >= 4)
+    assert macro_count >= 3  # All 3 macro items present
+
+
+def test_tiered_quota_fills_when_insufficient_macro():
+    items = [
+        {"id": "macro-1", "scope": 5, "score": 90},
+    ] + [
+        {"id": f"company-{i}", "scope": 1, "score": 80 - i} for i in range(9)
+    ]
+    result = apply_tiered_quota(items, macro_ratio=0.4)
+    assert len(result) == 10
+    assert result[0]["id"] == "macro-1"  # Macro first
+
+
+def test_tiered_quota_empty_list():
+    assert apply_tiered_quota([], macro_ratio=0.4) == []
+
+
+def test_tiered_quota_all_macro():
+    items = [{"id": f"m-{i}", "scope": 5, "score": 90 - i} for i in range(5)]
+    result = apply_tiered_quota(items, macro_ratio=0.4)
+    assert len(result) == 5  # All returned, no crash
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd backend && python -m pytest tests/test_tiered_quota.py -v`
+Expected: FAIL — module not found
+
+- [ ] **Step 3: Create quota module**
+
+Create `backend/src/pipelines/news/quota.py`:
+
+```python
+def apply_tiered_quota(
+    items: list[dict],
+    macro_ratio: float = 0.4,
+    macro_scope_threshold: int = 4,
+) -> list[dict]:
+    if not items:
+        return []
+
+    macro = [n for n in items if n.get("scope", 0) >= macro_scope_threshold]
+    other = [n for n in items if n.get("scope", 0) < macro_scope_threshold]
+
+    macro.sort(key=lambda x: x.get("score", 0), reverse=True)
+    other.sort(key=lambda x: x.get("score", 0), reverse=True)
+
+    total = len(items)
+    macro_slots = min(int(total * macro_ratio), len(macro))
+    other_slots = total - macro_slots
+
+    return macro[:macro_slots] + other[:other_slots] + macro[macro_slots:]
+```
+
+- [ ] **Step 4: Run quota tests**
+
+Run: `cd backend && python -m pytest tests/test_tiered_quota.py -v`
+Expected: ALL PASS
+
+- [ ] **Step 5: Update pools.py — global news, market for values only**
+
+In `backend/src/api/pools.py`:
+- Import: `from src.pipelines.news.quota import apply_tiered_quota`
+- In `get_pools` endpoint: change news query from `{"market": market, "status": "active"}` to `{"status": "active"}`
+- Apply `apply_tiered_quota(news_items)` before returning
+- Keep value entities query with market filter unchanged
+
+- [ ] **Step 6: Update thinking.py — replace legacy pool loading with entity-based loading**
+
+**IMPORTANT:** `thinking.py` currently loads from the legacy `pools` collection (lines 69-77), NOT from `news_entities`. The change is bigger than just removing a market filter:
+
+In `backend/src/api/thinking.py`:
+- Import: `from src.pipelines.news.quota import apply_tiered_quota`
+- Import: `from src.database.repositories.news_entity_repo import NewsEntityRepo`
+- Replace the legacy pool loading block (lines 68-88):
+
+```python
+# BEFORE (legacy — loads from "pools" collection with snapshots):
+pools_col = mongodb.get_collection("pools")
+news_pool = await pools_col.find_one(
+    {"type": "news", "date": req.date, "market": req.market}, {"_id": 0}
+)
+value_pool = await pools_col.find_one(
+    {"type": "value", "date": req.date, "market": req.market}, {"_id": 0}
+)
+news_items = (news_pool or {}).get("items", [])
+value_items = (value_pool or {}).get("items", [])
+
+# AFTER (entity-based — reads living entities directly):
+news_repo = NewsEntityRepo(mongodb.get_collection("news_entities"))
+all_news = await news_repo.get_active()  # No market filter — global
+news_items = apply_tiered_quota(
+    sorted(all_news, key=lambda x: x.get("score", 0), reverse=True),
+    macro_ratio=settings.news_macro_quota_ratio,
+)
+
+# Value pool: keep legacy path OR use value_entity_repo with market filter
+value_col = mongodb.get_collection("pools")
+value_pool = await value_col.find_one(
+    {"type": "value", "date": req.date, "market": req.market}, {"_id": 0}
+)
+value_items = (value_pool or {}).get("items", [])
+```
+
+Keep `req.market` in `StartRequest` — it's used for value pool filtering only. The live fallback (`fetch_real_news`, `fetch_real_stocks`) also stays for when entities are empty.
+
+- [ ] **Step 7: Run all tests**
+
+Run: `cd backend && python -m pytest tests/ -v --timeout=30`
+Expected: ALL PASS
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add backend/src/pipelines/news/quota.py backend/src/api/pools.py backend/src/api/thinking.py backend/tests/test_tiered_quota.py
+git commit -m "feat: global news pool with tiered quota — 40% macro guaranteed"
+```
+
+---
+
+### Task 10: Integration Test + Full Pipeline Verification
+
+**Files:**
+- Create: `backend/tests/test_macro_pipeline_integration.py`
+
+- [ ] **Step 1: Write integration test**
+
+```python
+# backend/tests/test_macro_pipeline_integration.py
+"""Integration test: full pipeline with macro news scoring and tiered quota."""
+import pytest
+from datetime import datetime, timezone
+from src.pipelines.news.score import NewsDecayScore
+from src.pipelines.news.quota import apply_tiered_quota
+
+
+def _make_news(id: str, scope: int, sources: int = 1, cluster: int = 1):
+    return {
+        "id": id, "title": f"News {id}", "scope": scope,
+        "story_cluster_size": cluster,
+        "sources": [f"s{i}" for i in range(sources)],
+        "last_seen_at": datetime.now(timezone.utc).isoformat(),
+    }
+
+
+def test_macro_news_dominates_pool():
+    scorer = NewsDecayScore()
+    macro_items = [
+        _make_news("geo-1", scope=5, sources=5, cluster=30),
+        _make_news("geo-2", scope=5, sources=3, cluster=20),
+        _make_news("macro-1", scope=4, sources=2, cluster=10),
+    ]
+    company_items = [
+        _make_news("co-1", scope=1, sources=2, cluster=1),
+        _make_news("co-2", scope=1, sources=1, cluster=1),
+        _make_news("co-3", scope=2, sources=1, cluster=1),
+        _make_news("co-4", scope=2, sources=1, cluster=1),
+    ]
+    all_items = macro_items + company_items
+    for item in all_items:
+        sr = scorer.score(item)
+        item["score"] = sr.score
+
+    macro_scores = [i["score"] for i in macro_items]
+    company_scores = [i["score"] for i in company_items]
+    assert min(macro_scores) > max(company_scores)
+
+    pool = apply_tiered_quota(all_items, macro_ratio=0.4)
+    top_3 = pool[:3]
+    assert all(i["scope"] >= 4 for i in top_3)
+
+
+def test_scoring_no_ticker_penalty():
+    scorer = NewsDecayScore()
+    news_no_tickers = _make_news("geo", scope=5, sources=3, cluster=15)
+    news_no_tickers["tickers"] = []
+    news_with_tickers = _make_news("co", scope=1, sources=3, cluster=1)
+    news_with_tickers["tickers"] = ["AAPL", "MSFT"]
+
+    assert scorer.score(news_no_tickers).score > scorer.score(news_with_tickers).score
+```
+
+- [ ] **Step 2: Run integration test**
+
+Run: `cd backend && python -m pytest tests/test_macro_pipeline_integration.py -v`
+Expected: ALL PASS
+
+- [ ] **Step 3: Run full test suite**
+
+Run: `cd backend && python -m pytest tests/ -v --timeout=60`
+Expected: ALL PASS — no regressions
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add backend/tests/test_macro_pipeline_integration.py
+git commit -m "test: integration test for macro news scoring + tiered quota"
+```

--- a/docs/superpowers/specs/2026-03-24-macro-news-pipeline-design.md
+++ b/docs/superpowers/specs/2026-03-24-macro-news-pipeline-design.md
@@ -1,0 +1,444 @@
+# Macro News Pipeline Redesign
+
+**Date:** 2026-03-24
+**Status:** Draft
+**Problem:** The news pool is too narrow — dominated by company/ticker-specific financial news. Macro signals (geopolitics, climate, trade policy, resource shifts) are the *causes* that the Thinker agent needs to reason from, but the current fetch and scoring pipeline suppresses them.
+
+## Design Decisions
+
+| Decision | Choice | Rationale |
+|----------|--------|-----------|
+| Fetch strategy | Perigon `/stories` + `/all` + NewsAPI | Multiple sources for breadth; `/stories` clusters high-coverage events |
+| Scoring | Replace `ticker_relevance` with `scope_factor` + `cluster_factor` | Stop penalizing ticker-less macro news |
+| Pool structure | Tiered with 40% macro quota | Guarantee Thinker always has causal seeds |
+| Market partition | Removed from news | News is global; market filter only on value pool |
+| Agent fetch | `fetch_news` tool for directed search | Agent can actively pull evidence mid-reasoning |
+| NewsAPI tier | Free (24h delay acceptable) | Supplementary source, not real-time |
+
+## 1. Data Model Changes
+
+### NewsEntity (modified)
+
+```python
+class NewsEntity(BaseModel):
+    id: str
+    canonical_title: str
+    summary: str
+    sources: list[str] = []
+    tickers: list[str] = []
+    sectors: list[str] = []
+    named_entities: list[str] = []
+    embedding: list[float] = []
+    scope: int = 2                     # NEW: 1-5 (1=company, 5=global/geopolitical)
+    score: float = 0.0
+    score_factors: dict[str, float] = {}
+    first_seen_at: datetime
+    last_seen_at: datetime
+    status: EntityStatus = EntityStatus.ACTIVE
+    origin: str = "perigon"            # NEW: "perigon" | "newsapi" | "agent_fetch"
+    story_cluster_size: int = 1        # NEW: article count from /stories clustering
+```
+
+**Removed:** `market: str` — news doesn't belong to a market. The `ValueEntity` retains its market field.
+
+**Added:**
+- `scope` (int, 1-5): Persisted from `_classify_scope`. Drives tiered quota enforcement.
+  - 1 = single company/ticker
+  - 2 = sector-level
+  - 3 = industry/trend
+  - 4 = national/macro (monetary policy, GDP, inflation)
+  - 5 = global/geopolitical (sanctions, trade wars, OPEC, climate summits)
+- `origin` (str): Tracks data source for debugging and rate limit accounting.
+- `story_cluster_size` (int): From Perigon `/stories` — number of articles clustered under this story. Higher = broader coverage = likely more impactful.
+
+## 2. Scoring Redesign
+
+### Current formula (biased against macro news)
+```
+score = 0.5 * freshness + 0.3 * source_count + 0.2 * ticker_relevance
+```
+Macro news has zero tickers → gets 0 on 20% of the score → systematically ranked below company news.
+
+### New formula
+```
+score = 0.4 * freshness + 0.25 * source_count + 0.2 * scope_factor + 0.15 * cluster_factor
+```
+
+| Factor | Calculation | Purpose |
+|--------|------------|---------|
+| `freshness` | `0.5 ^ (age_days / half_life_days)` | Same exponential decay (half-life 3 days) |
+| `source_count` | `min(1.0, 0.2 + 0.2 * len(sources))` | More sources = higher confidence |
+| `scope_factor` | `scope / 5.0` | Macro (5) → 1.0, company (1) → 0.2 |
+| `cluster_factor` | `min(1.0, story_cluster_size / 20)` | 20+ articles in cluster → max score. Default 1 for non-story items → 0.05 |
+
+**Note:** The existing `_classify_impact` and `scope_impact` fields in `perigon.py` are deprecated by this formula. The `scope` field is reused from `_classify_scope` (already implemented in `perigon.py:69-135`), and `cluster_factor` replaces impact-based ranking. The `impact` and `scope_impact` fields on pool items can be retained for backward compatibility but are no longer used in scoring.
+
+### Worked examples
+
+| Article | freshness | source_count | scope_factor | cluster_factor | **Old score** | **New score** |
+|---------|-----------|-------------|-------------|---------------|--------------|--------------|
+| "China bans rare earth exports" (1 day old, 3 sources, scope=5, cluster=25) | 0.79 | 0.80 | 1.00 | 1.00 | 0.79×50 + 0.80×30 + 0×20 = **63.5** | 0.79×40 + 0.80×25 + 1.0×20 + 1.0×15 = **86.6** |
+| "AAPL beats Q2 earnings" (1 day old, 2 sources, scope=1, cluster=1, 1 ticker) | 0.79 | 0.60 | 0.20 | 0.05 | 0.79×50 + 0.60×30 + 0.30×20 = **63.5** | 0.79×40 + 0.60×25 + 0.20×20 + 0.05×15 = **51.35** |
+| "Fed holds rates steady" (1 day old, 5 sources, scope=4, cluster=15) | 0.79 | 1.00 | 0.80 | 0.75 | 0.79×50 + 1.0×30 + 0×20 = **69.5** | 0.79×40 + 1.0×25 + 0.80×20 + 0.75×15 = **83.85** |
+
+The new formula correctly prioritizes macro/geopolitical news while keeping company news visible at a lower rank.
+
+### Tiered quota
+
+When assembling the pool for display or session creation, enforce:
+
+- **At least 40% of pool items must be scope >= 4** (macro/geopolitical)
+- If fewer than 40% macro items exist, fill with whatever is available (no artificial inflation)
+- This is a **presentation-layer filter**, not a storage filter — all news is persisted regardless
+
+```python
+def apply_tiered_quota(items: list[dict], macro_ratio: float = 0.4) -> list[dict]:
+    macro = [n for n in items if n.get("scope", 0) >= 4]
+    other = [n for n in items if n.get("scope", 0) < 4]
+
+    total = len(items)
+    macro_slots = int(total * macro_ratio)
+    other_slots = total - min(macro_slots, len(macro))
+
+    return macro[:macro_slots] + other[:other_slots]
+```
+
+## 3. Fetch Architecture
+
+Three fetch modes serve different purposes in the pipeline.
+
+### Mode 1: Cron — Perigon `/stories` (Seed Pool)
+
+Primary source for Layer 0 seed selection. The `/stories` endpoint clusters related articles into story objects — high article count naturally surfaces breaking/impactful events.
+
+```
+Schedule: Every 2 hours
+Endpoint: GET /v1/stories
+Params:
+  category: ["Politics", "World", "Environment", "Business", "Science"]
+  excludeLabel: ["Opinion", "Non-news", "Paid News"]
+  sortBy: date
+  size: 20
+  sourceGroup: top100
+```
+
+Each story's `articles_count` is stored as `story_cluster_size`. The story's title and summary become the `NewsEntity`.
+
+### Mode 2: Cron — Perigon `/all` + NewsAPI `/top-headlines` (Broad Pool)
+
+Supplements the seed pool with broader coverage for agent reference during deeper layers.
+
+```
+# Perigon /all — every 2 hours
+GET /v1/all
+  category: ["Politics", "World", "Environment", "Business", "Finance"]
+  excludeLabel: ["Opinion", "Non-news", "Paid News"]
+  sortBy: relevance
+  size: 20
+
+# NewsAPI /top-headlines — every 4 hours (budget: 100 req/day free tier)
+GET /v2/top-headlines
+  category: general
+  language: en
+  pageSize: 50
+```
+
+Both normalize to the same `NewsEntity` format. Origin tracked via `origin` field.
+
+### Mode 3: Agent Tool — `fetch_news` (On-Demand)
+
+The Thinker agent can actively search for news during reasoning when it identifies information gaps.
+
+```python
+class FetchNewsTool:
+    """Agent tool for directed news search during causal reasoning."""
+    name = "fetch_news"
+    description = "Search for news articles on a specific topic to fill information gaps."
+
+    async def run(self, query: str, max_results: int = 5) -> list[dict]:
+        # Check rate limits before hitting APIs
+        if not await has_api_budget():
+            return await fallback_text_search(query)  # Search existing pool
+
+        # Perigon /all first (richer metadata)
+        results = await fetch_perigon_news(query=query, size=max_results)
+
+        # Supplement with NewsAPI /everything if needed
+        if len(results) < max_results:
+            newsapi_results = await fetch_newsapi_everything(
+                query=query, sort_by="relevancy",
+                page_size=max_results - len(results)
+            )
+            results.extend(newsapi_results)
+
+        # Dedup against existing pool, persist new finds
+        for item in results:
+            await pipeline.process_and_store(item)
+
+        return results
+```
+
+**Rate limit protection:** Checks daily call counts before hitting APIs. If exhausted, falls back to text search against existing `news_entities` collection.
+
+**DAG integration:** Fetched news becomes "fetch" nodes in the thinking DAG, same as today. But now they can come from live API calls, not just the pre-loaded pool.
+
+## 4. Pipeline Changes
+
+### Remove market partition
+
+```python
+# Before
+build_news_pipeline(market="US", repo=news_repo)
+build_news_pipeline(market="CN", repo=news_repo)
+
+# After
+build_news_pipeline(repo=news_repo)  # Single global pipeline
+```
+
+The `news_entities` collection becomes a single global pool. The `value_entities` collection retains its market partition.
+
+### PoolPipeline contract changes
+
+The current `PoolPipeline` (`pipelines/base.py`) requires `market: str` in `__init__`, passes it to `fetch.fetch(market)`, and uses it in `repo.get_all(market=market)`. These must change:
+
+```python
+# Before (base.py)
+class PoolPipeline:
+    def __init__(self, fetch, process, score, retain, repo, market: str): ...
+    async def run(self):
+        raw = await self.fetch.fetch(self.market)
+        existing = await self.repo.get_all(market=self.market, ...)
+
+# After
+class PoolPipeline:
+    def __init__(self, fetch, process, score, retain, repo, market: str | None = None): ...
+    async def run(self):
+        raw = await self.fetch.fetch() if self.market is None else await self.fetch.fetch(self.market)
+        existing = await self.repo.get_all(market=self.market, ...)  # None = all markets
+```
+
+- `market` becomes `Optional[str]` with default `None`
+- `BaseFetch.fetch()` interface gains an optional `market` param — news fetchers ignore it, value fetchers use it
+- `NewsEntityRepo.get_all(market=None)` returns all entities (no market filter)
+- `ValueEntityRepo.get_all(market="US")` still requires market — unchanged
+
+### Dedup ID generation
+
+The current `_gen_id` in `process.py` hashes `"{market}:{title}:{date}"`. With market removed from news:
+
+```python
+# Before
+def _gen_id(self, raw: dict) -> str:
+    return hashlib.sha256(f"{market}:{title}:{date}".encode()).hexdigest()[:16]
+
+# After
+def _gen_id(self, raw: dict) -> str:
+    return hashlib.sha256(f"{title}:{date}".encode()).hexdigest()[:16]
+```
+
+**Migration note:** Existing entities keep their old market-prefixed IDs. New entities get market-free IDs. The hybrid similarity dedup (title + entity Jaccard) will naturally merge duplicates over time — a new market-free version of "Fed holds rates" will match the existing "US:Fed holds rates" entity by title similarity ≥ 0.6 and merge into it. No one-time migration script needed.
+
+### Composite fetch strategy
+
+```python
+class CompositeFetch:
+    """Runs multiple fetch strategies and merges results."""
+    def __init__(self, fetchers: list[BaseFetch]):
+        self.fetchers = fetchers
+
+    async def fetch(self) -> list[dict]:
+        results = []
+        for f in self.fetchers:
+            try:
+                results.extend(await f.fetch())
+            except Exception as e:
+                log.warning("Fetcher %s failed: %s", f.__class__.__name__, e)
+        return results
+```
+
+**Interface change:** `BaseFetch.fetch()` becomes a no-arg method for news fetchers. The `CompositeFetch` calls `f.fetch()` with no arguments. Value pipeline fetchers retain `fetch(market)` via the `PoolPipeline`'s market-aware path.
+
+### Cron orchestration
+
+```python
+def build_news_pipeline(repo: NewsEntityRepo) -> PoolPipeline:
+    return PoolPipeline(
+        fetch=CompositeFetch([
+            PerigonStoriesFetch(),    # /stories — clustered macro events
+            PerigonAllFetch(),        # /all — broad coverage
+            NewsAPIHeadlinesFetch(),  # /top-headlines — breaking
+        ]),
+        process=HybridSimilarityProcess(threshold=0.6),
+        score=NewsDecayScore(),       # Updated formula with scope + cluster
+        retain=ThresholdRetain(),
+        repo=repo,
+        market=None,                  # Global — no market partition
+    )
+```
+
+## 5. NewsAPI Client
+
+New service: `backend/src/services/newsapi.py`
+
+```python
+NEWSAPI_BASE_URL = "https://newsapi.org/v2"
+
+async def fetch_newsapi_headlines(
+    category: str = "general",
+    language: str = "en",
+    page_size: int = 50,
+) -> list[dict]:
+    """Fetch breaking headlines from /top-headlines.
+    Free tier: 24h delay, 100 req/day, dev-only license.
+    """
+
+async def fetch_newsapi_everything(
+    query: str,
+    sort_by: str = "relevancy",
+    page_size: int = 10,
+) -> list[dict]:
+    """Search all articles via /everything.
+    Used by the agent fetch_news tool for directed search.
+    """
+```
+
+Both return items normalized to pool format (same shape as Perigon items). Cached in MongoDB (`newsapi_cache` collection) with same pattern as Perigon.
+
+### Normalization
+
+NewsAPI items are converted to match our pool format:
+
+```python
+def _newsapi_to_pool_item(article: dict, origin: str = "newsapi") -> dict:
+    return {
+        "id": f"na-{hashlib.sha256(article['url'].encode()).hexdigest()[:10]}",
+        "type": "news_event",
+        "title": article.get("title", ""),
+        "source": article.get("source", {}).get("name", "Unknown"),
+        "url": article.get("url", ""),
+        "summary": article.get("description", "")[:200],
+        "published_at": article.get("publishedAt", ""),
+        "direction": "neutral",  # NewsAPI has no sentiment
+        "confidence": 50,        # Default — no sentiment data
+        "sectors": _infer_sectors_from_title(article.get("title", "")),  # Keyword-based
+        "scope": _infer_scope_from_title(article.get("title", "")),     # Keyword-based
+        "origin": origin,
+        "story_cluster_size": 1, # Not applicable for NewsAPI
+    }
+```
+
+## 6. Agent Integration
+
+### Thinker agent tool registration
+
+The `fetch_news` tool is registered alongside existing tools in the Thinker agent's tool belt:
+
+```python
+thinker_tools = [
+    FetchNewsTool(pipeline=news_pipeline),  # NEW
+    # ... existing tools
+]
+```
+
+**Sync/async boundary:** The current `run_thinker` in `thinking_crew.py` is a sync `def`. `FetchNewsTool.run()` is `async def` because it calls async API clients. Resolution: `FetchNewsTool` exposes a sync `_run()` wrapper that uses `asyncio.run()` or the CrewAI tool's built-in async support. Implementation should check CrewAI's tool interface — if it natively supports async tools, use that; otherwise, wrap with sync.
+
+### Thinker reasoning flow (updated)
+
+```
+1. Receive: parent_nodes + chain_summary + news_pool (top 20, tiered)
+2. Reason about causal effects from parent nodes
+3. FOR EACH information gap identified:
+   a. Call fetch_news("targeted query") → get relevant articles
+   b. Incorporate into reasoning as additional evidence
+4. Output effects with:
+   - reasoning (causal chain)
+   - confidence
+   - parent_ids (can include freshly fetched news IDs)
+   - information_gaps (remaining gaps after fetch attempts)
+```
+
+### Pool loading for sessions (updated)
+
+```python
+# Before: market-filtered
+news_pool = await news_repo.find({"market": req.market, "status": "active"})
+
+# After: global pool with tiered quota
+all_active = await news_repo.find({"status": "active"}).sort("score", -1).to_list()
+pool = apply_tiered_quota(all_active, macro_ratio=0.4)
+```
+
+### API contract: `StartRequest.market` retained for value pool only
+
+```python
+class StartRequest(BaseModel):
+    date: str
+    market: str = "US"          # KEPT — used for value pool filtering only
+    max_depth: int = 3
+    selected_news_ids: list[str] | None = None
+```
+
+- News pool query: `{"status": "active"}` (no market filter)
+- Value pool query: `{"market": req.market, "status": "active"}` (market-filtered as before)
+- Session document retains `market` field for the value pool context
+
+### Frontend impact
+
+No frontend changes required for the news pool. The `GET /api/pools/{date}?market=US` endpoint continues to accept `market` but applies it only to the value pool response. News items are returned globally regardless of the `market` param. The frontend's pool display component will see more diverse news without code changes.
+
+## 7. Rate Limit Budget
+
+| Source | Limit | Cron | Agent Tool | Hard Cap |
+|--------|-------|------|------------|----------|
+| Perigon | 150 calls/month (~5/day) | 3/day (stories + all) | 2/day | 5/day |
+| NewsAPI (free) | 100 calls/day | 6/day (every 4h) | 44/day max | 50/day |
+
+**Agent tool cap:** The `fetch_news` tool enforces a per-source daily cap for agent-initiated calls. When the cap is reached, it falls back to `fallback_text_search` — a MongoDB text search against the existing `news_entities` collection using `$text` index on `canonical_title` + `summary`. This ensures the agent always gets results, even when API budget is exhausted.
+
+Centralized tracking in MongoDB:
+- `perigon_usage` collection (existing) — tracks daily Perigon calls
+- `newsapi_usage` collection (new) — tracks daily NewsAPI calls
+- `fetch_news` tool checks both before making calls
+- Each call is tagged with `source: "cron" | "agent"` for budget accounting
+
+## 8. Migration
+
+### Database
+- `news_entities` collection: no destructive migration needed
+  - New fields (`scope`, `origin`, `story_cluster_size`) default to safe values
+  - `market` field can remain on existing docs (ignored, eventually cleaned up)
+  - Add index on `scope` for tiered quota queries
+
+### API
+- `GET /api/pools/{date}` — remove `market` filter from news query, keep for values
+- `POST /api/thinking` — update pool loading to use global news + tiered quota
+
+### Config
+- Add `NEWSAPI_API_KEY` to environment config
+- Add `news_macro_quota_ratio` to `core/config.py` (default 0.4)
+- Add `newsapi_daily_limit` to config (default 100)
+
+## 9. Files Affected
+
+| File | Change |
+|------|--------|
+| `backend/src/models/news_entity.py` | Add `scope`, `origin`, `story_cluster_size`; remove `market` |
+| `backend/src/pipelines/base.py` | Make `market` optional in `PoolPipeline.__init__`, conditional market passing |
+| `backend/src/pipelines/news/score.py` | New formula with `scope_factor` + `cluster_factor` |
+| `backend/src/pipelines/news/fetch.py` | `PerigonStoriesFetch`, `PerigonAllFetch`, `NewsAPIHeadlinesFetch`, `CompositeFetch` |
+| `backend/src/pipelines/news/process.py` | Remove `market` from `_gen_id` hash |
+| `backend/src/services/newsapi.py` | **New** — NewsAPI client with caching + keyword-based scope/sector inference |
+| `backend/src/services/perigon.py` | Add `fetch_perigon_stories()`, broaden categories |
+| `backend/src/agents/tools/fetch_news.py` | **New** — agent tool for directed news search |
+| `backend/src/agents/thinking_crew.py` | Register `FetchNewsTool`, handle sync/async boundary |
+| `backend/src/api/pools.py` | Remove market filter on news, add tiered quota |
+| `backend/src/api/thinking.py` | Update session creation — global news pool, market for values only |
+| `backend/src/cron/scheduler.py` | Single news pipeline (market=None) |
+| `backend/src/core/config.py` | Add `news_macro_quota_ratio`, `newsapi_daily_limit`, `newsapi_agent_cap` |
+| `backend/src/database/repos/news_entity_repo.py` | Support `market=None` in `get_all()` and `get_active()` |
+
+## 10. Open Questions
+
+1. **Perigon `/stories` response shape** — need to verify exact fields during implementation. The design assumes `title`, `summary`, `articles_count` exist on story objects.
+2. **NewsAPI free tier ToS** — "development only." If this goes to production, need paid tier (~$449/month). Acceptable for current dev/research phase.
+3. **Scope classification for NewsAPI items** — NewsAPI has no pre-classified metadata. Items use `_infer_scope_from_title()` and `_infer_sectors_from_title()` — lightweight keyword-based classifiers reusing the same keyword sets from Perigon's `_classify_scope`. Accuracy will be lower than Perigon's metadata-driven classification, but sufficient for dedup and scoring. Empty sectors would cause NewsAPI items to fail Jaccard dedup against Perigon versions of the same story — keyword inference prevents this.

--- a/docs/superpowers/specs/2026-03-26-sse-streaming-thinking-design.md
+++ b/docs/superpowers/specs/2026-03-26-sse-streaming-thinking-design.md
@@ -1,0 +1,287 @@
+# SSE Streaming for Thinking Pipeline
+
+**Issue:** #16 — Replace polling with SSE for auto-run progress
+**Date:** 2026-03-26
+**Status:** Approved
+
+## Problem
+
+The auto-run thinking pipeline uses 2-second HTTP polling to track progress. This adds 0-2s latency to node appearance, floods backend logs with redundant GET requests, and provides a poor user experience — users stare at a static screen for 20-40s per layer, then see all nodes appear at once.
+
+An SSE endpoint exists (`GET /api/thinking/{id}/events`) but is unused by the frontend and internally polls MongoDB every 0.5s (polling-disguised-as-SSE).
+
+## Solution
+
+Replace polling with true SSE streaming powered by LLM token-level streaming. Nodes appear on the graph **as the LLM generates them**, with content filling in word-by-word. The experience is similar to watching ChatGPT stream a response, but manifested as graph nodes.
+
+## Architecture
+
+### Backend: Streaming Pipeline
+
+#### LLM Streaming
+
+The thinker agent (the slow part, 20-40s per layer) switches from CrewAI's `crew.kickoff()` (batch) to **direct LiteLLM streaming** calls with the same prompt and system message. SiliconFlow's OpenAI-compatible API supports `stream=True`.
+
+The matcher and controller agents stay on CrewAI `kickoff()` — they're fast (<5s each) and don't benefit from streaming.
+
+#### Sync/Async Boundary
+
+Currently `run_layer()` wraps synchronous CrewAI calls in `loop.run_in_executor()`. The new streaming path introduces `run_layer_streaming()` — a **natively async** function that calls `litellm.acompletion(stream=True)` directly. No executor needed.
+
+Both functions coexist:
+- **`run_layer()`** (sync via executor) — used for manual step mode (`POST /thinking/{id}/step`)
+- **`run_layer_streaming()`** (async, pushes to queue) — used for auto-run mode (`POST /thinking/auto`)
+
+The `run_pipeline()` loop calls `run_layer_streaming()` instead of `run_layer()` when in auto-run mode. The `on_layer_complete` callback is replaced by direct `queue.put()` calls from within `run_layer_streaming()`.
+
+#### Incremental JSON Parsing
+
+As LLM tokens arrive, an incremental parser (using `json-repair` — **new dependency, to be added to `pyproject.toml`**) attempts to extract complete node objects from the partial JSON. The parser must handle:
+
+- **Nested arrays:** The thinker returns `{"effects": [{...}, {...}]}`. The parser tracks bracket depth to detect when a complete object within the `effects` array closes, not when the outer object closes.
+- **Markdown fencing:** LLMs may wrap output in ` ```json ... ``` ` despite the prompt saying "Return ONLY valid JSON." The parser strips markdown fences from the stream prefix before attempting JSON parsing.
+
+```
+LLM stream: {"effects": [{"content": "Fed rate pause signals...
+                          ↑ parser detects first node starting
+
+LLM stream: ..."confidence": 78, "parent_ids": ["seed1"]}
+                                                          ↑ first node complete → emit
+```
+
+Each complete field update is emitted as a word-level delta to the frontend.
+
+#### Session Event Queue
+
+Each active auto-run session gets an `asyncio.Queue`. The pipeline task pushes events into the queue; the SSE endpoint awaits events from it.
+
+```
+Pipeline task → queue.put(event) → SSE endpoint → queue.get() → browser
+```
+
+Zero polling. Instant delivery. The queue is created when auto-run starts and cleaned up when the session completes or the SSE client disconnects.
+
+**Queue registry:**
+```python
+_session_queues: dict[str, asyncio.Queue] = {}
+```
+
+**Lifecycle sequencing:** The queue is created in `auto_think()` **before** `asyncio.create_task()` launches the pipeline. This guarantees no events are lost — the pipeline can push immediately, and the SSE endpoint attaches to the existing queue. If no queue exists when the SSE endpoint connects (session already complete), replay from MongoDB.
+
+**Cancellation:** The `asyncio.Task` handle is stored alongside the queue in the session registry. On SSE disconnect or explicit cancel request, `task.cancel()` is called. The pipeline catches `asyncio.CancelledError` and cleans up gracefully (persists any completed layers to MongoDB before exiting).
+
+```python
+_session_registry: dict[str, SessionEntry] = {}
+
+@dataclass
+class SessionEntry:
+    queue: asyncio.Queue
+    task: asyncio.Task
+    created_at: float
+```
+
+**Memory guard:** If a queue exceeds 500 items (consumer disconnected but producer keeps pushing), log a warning, cancel the pipeline task, and clean up the session. A periodic health check (every 30s) logs total queue count and any queues above 100 items.
+
+```python
+MAX_QUEUE_SIZE = 500
+WARN_QUEUE_SIZE = 100
+
+async def _queue_health_check():
+    """Periodic check — runs every 30s while any sessions are active."""
+    for sid, entry in list(_session_registry.items()):
+        q = entry.queue
+        if q.qsize() > MAX_QUEUE_SIZE:
+            log.error("Session %s queue overflow (%d items) — cancelling session", sid, q.qsize())
+            entry.task.cancel()
+            del _session_registry[sid]
+        elif q.qsize() > WARN_QUEUE_SIZE:
+            log.warning("Session %s queue backpressure: %d items", sid, q.qsize())
+    if _session_registry:
+        log.info("Active SSE sessions: %d, total queued events: %d",
+                 len(_session_registry),
+                 sum(e.queue.qsize() for e in _session_registry.values()))
+```
+
+### SSE Event Protocol
+
+All events use standard SSE format (`event:`, `data:`, `id:` fields).
+
+#### Event Types
+
+```
+event: node_start
+id: layer:1:node:0
+data: {"id": "abc123", "layer": 1, "type": "effect", "parent_ids": ["seed1"]}
+
+event: node_text
+id: layer:1:node:0:text:5
+data: {"id": "abc123", "field": "content", "delta": "Fed rate pause "}
+
+event: node_text
+id: layer:1:node:0:text:12
+data: {"id": "abc123", "field": "reasoning", "delta": "The 25bp hold despite "}
+
+event: node_complete
+id: layer:1:node:0:done
+data: {"id": "abc123", "confidence": 78, "metadata": {"sector": "economy_macro", "information_gaps": [...]}}
+
+event: edges
+id: layer:1:edges
+data: [{"source": "seed1", "target": "abc123", "relationship": "causes"}, ...]
+
+event: layer_complete
+id: layer:1:complete
+data: {"layer": 1, "controller": {"continue": true, "reasoning": "...", "summary": "..."}}
+
+event: session_complete
+id: session:complete
+data: {"status": "complete"}
+
+event: error
+id: error
+data: {"message": "Thinker agent timed out", "layer": 1}
+```
+
+#### Event Sequencing Per Layer
+
+```
+[thinker streams — slow, 20-40s]
+  node_start → node_text... → node_complete   (repeat per node)
+
+[matcher runs — fast, ~5s]
+  node_start → node_complete                   (opportunity nodes, no streaming)
+  edges                                         (cause + match edges)
+
+[controller runs — fast, ~3s]
+  layer_complete                                (continue/stop decision)
+```
+
+### Frontend: Streaming Graph with Animations
+
+#### New Hook: `useSSESession(sessionId)`
+
+Manages `EventSource` lifecycle and exposes an event-driven API:
+
+- Opens `EventSource` to `/api/thinking/{sessionId}/events`
+- Dispatches events to handler callbacks
+- Handles reconnection with `Last-Event-ID` replay
+- Falls back to 2s polling after 3 failed connection attempts (15s total)
+
+#### Node Entrance Animation
+
+1. **`node_start`** → Create React Flow node at center (0, 0) with `opacity: 0`. Calculate target position on concentric ring. Animate to target via CSS `transition: all 400ms ease-out`.
+
+2. **`node_text`** → Append delta words to displayed content. Node component re-renders with new text (like watching someone type). Content area auto-expands.
+
+3. **`node_complete`** → Render confidence badge, sector tag. Subtle border glow animation (200ms).
+
+4. **`edges`** → Draw edges with animated SVG `stroke-dashoffset` (line draws from source to target over 300ms). Queue edges if target node isn't visible yet.
+
+#### Deterministic Concentric Ring Layout
+
+During SSE streaming, positions are calculated deterministically (no d3-force). d3-force remains for initial full-session loads (reconnect replay, manual mode refresh) where all nodes are known upfront. The deterministic layout avoids re-running the force simulation on every incoming node.
+
+```
+Layer 0 (seeds): center cluster, radius = 0
+Layer 1: ring at radius = 200px, nodes evenly spaced
+Layer 2: ring at radius = 400px
+Layer 3: ring at radius = 600px
+```
+
+Angle per node: `(index / totalInLayer) * 2π + layerRotationOffset`
+
+Since total nodes per layer isn't known upfront, existing nodes **re-space** as new siblings arrive (smooth 200ms CSS transition — nodes scoot over to make room).
+
+#### Stagger Timing
+
+- Nodes appear naturally staggered by LLM generation speed (~300ms apart)
+- Minimum 200ms gap enforced between `node_start` renders (prevents visual clumping if LLM bursts)
+- Text streams at LLM token rate (~50-100ms per word chunk)
+- Edges appear 150ms after target node reaches full opacity
+
+#### Manual Step Compatibility
+
+Manual `handleStep()` still works via REST. The step response (full nodes + edges) is fed through the same animation queue for consistent entrance animations. No SSE connection needed for manual mode.
+
+### Reconnection and Fallback
+
+#### SSE Reconnection
+
+`EventSource` natively reconnects on connection drop. Each event has an `id` field. On reconnect, the browser sends `Last-Event-ID`. The backend replays **completed layers** from MongoDB (nodes are persisted at layer completion). Replayed events skip animation — rendered instantly at final positions.
+
+**Mid-layer reconnection gap:** If the client disconnects while the thinker is mid-stream, individual `node_text` deltas are NOT persisted to MongoDB. On reconnect, completed layers replay from DB; the in-progress layer's streamed nodes are only available if the queue still has unconsumed events. If the queue was cleaned up, the client sees a gap until the current layer completes and is persisted. This is acceptable — the layer will finish within seconds.
+
+#### Polling Fallback
+
+If `EventSource` fails to connect after 3 attempts (5s timeout each), the frontend falls back to the existing 2s polling path. The polling code stays in the codebase as the fallback path.
+
+#### Error Handling
+
+- **LLM timeout** (60s per agent) → `error` event with layer info. Frontend shows which layer failed.
+- **Partial layer** (3 of 5 nodes generated before error) → already-streamed nodes stay visible. `error` event marks layer incomplete.
+- **SSE disconnect mid-stream** → reconnect replays from `Last-Event-ID`. Already-animated nodes stay in place.
+- **Queue overflow** (>500 items) → session dropped, error logged, client reconnects and gets current state from MongoDB.
+
+## Files Changed
+
+### Backend (modify)
+
+| File | Change |
+|------|--------|
+| `backend/src/api/thinking_auto.py` | Replace polling-based SSE with queue-based SSE; add queue registry, health check, reconnection replay |
+| `backend/src/services/thinking_service.py` | Add `run_layer_streaming()` — direct LiteLLM calls with `stream=True` for thinker; incremental JSON parser |
+| `backend/src/agents/thinking_crew.py` | Extract thinker prompt/system message into reusable constants (shared between CrewAI and direct LiteLLM path) |
+| `backend/src/agents/llm_config.py` | Add `get_litellm_params()` — returns dict with model, api_key, base_url for direct LiteLLM streaming calls |
+
+### Backend (new)
+
+| File | Purpose |
+|------|---------|
+| `backend/src/services/stream_parser.py` | Incremental JSON parser — consumes token chunks, emits complete node objects and field deltas |
+| `backend/src/services/session_events.py` | Session registry (queue + task handle + created_at), event types (dataclasses), health check task, cancellation, cleanup logic |
+
+### Frontend (modify)
+
+| File | Change |
+|------|--------|
+| `frontend/src/components/ThinkingView.tsx` | Replace `setInterval` polling with `useSSESession` hook; feed events through animation queue; keep polling as fallback |
+| `frontend/src/lib/thinking-graph-builder.ts` | Add `concentricPosition(layer, index, total)` layout function alongside existing d3-force (force stays for initial/manual load) |
+| `frontend/src/services/api.ts` | No change — REST endpoints unchanged |
+
+### Frontend (new)
+
+| File | Purpose |
+|------|---------|
+| `frontend/src/hooks/useSSESession.ts` | EventSource lifecycle, reconnection, fallback to polling |
+| `frontend/src/hooks/useAnimationQueue.ts` | Stagger node entrance timing, minimum gap enforcement |
+| `frontend/src/components/StreamingNode.tsx` | Custom React Flow node component with text streaming, entrance animation, expand-on-content |
+
+### Tests
+
+| File | Coverage |
+|------|----------|
+| `backend/tests/test_stream_parser.py` | Incremental JSON parsing: partial chunks → complete nodes; malformed JSON recovery; field delta emission |
+| `backend/tests/test_session_events.py` | Queue lifecycle: create, put, get, cleanup on disconnect; overflow warning/drop; health check logging |
+| `backend/tests/test_sse_endpoint.py` | SSE event format; reconnection replay with Last-Event-ID; error event on LLM timeout |
+| `frontend/src/hooks/__tests__/useSSESession.test.ts` | EventSource mock: events → state updates; reconnection; fallback to polling |
+| `frontend/src/hooks/__tests__/useAnimationQueue.test.ts` | Stagger timing; minimum gap; queue drain |
+| `frontend/src/lib/__tests__/concentric-layout.test.ts` | Position calculation: layer rings, re-spacing on new node arrival |
+
+## What Stays Unchanged
+
+- Manual step flow (`POST /thinking/{sessionId}/step`) — same API, response fed through animation queue
+- Matcher and controller agents — still CrewAI `kickoff()`, not streaming
+- MongoDB persistence — same `_on_layer_complete` writes
+- Node toggle/deselect cascading — same `PATCH` endpoint
+- Pool loading — unrelated to thinking session streaming
+- All existing REST endpoints — SSE is additive, not replacing REST
+
+## Scaling Path
+
+Current design handles ~10 concurrent auto-run sessions comfortably (in-memory queues, single worker). If scaling beyond that:
+
+1. Add uvicorn workers (`--workers 4`)
+2. Swap `asyncio.Queue` for Redis pub/sub (queue lives outside process)
+3. Queue registry becomes Redis-backed
+
+The event protocol and frontend code don't change — only the queue transport layer.


### PR DESCRIPTION
## Summary
- Collects 9 orphaned files that accumulated across recent merged PRs but were never committed
- No code changes — planning docs, specs, and one project rule file
- Matches existing naming/structure patterns in `docs/superpowers/{plans,specs}`

### Files
- `.claude/rules/cron-run-on-start-must-be-nonblocking.md` (from PR #42 work)
- `backend/tests/quality-gates.md` (from PR #41 work)
- `docs/superpowers/plans/2026-03-{24,26}-*.md` + `macro-news-pipeline/` subfolder
- `docs/superpowers/specs/2026-03-{24,26}-*-design.md`

## Test plan
- [x] Main repo working tree clean after move
- [x] Worktree committed only intended files (`git status` clean)
- [ ] CI passes (no code changes expected to affect anything)

🤖 Generated with [Claude Code](https://claude.com/claude-code)